### PR TITLE
Update docker-compose.yml

### DIFF
--- a/Apps/homarr/docker-compose.yml
+++ b/Apps/homarr/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       # Mounting the local homarr/icons directory to /app/public/icons inside the container
       - /DATA/AppData/$AppID/icons:/app/public/icons
 
+      # Mounting docker.sock to allow docker management via Homarr
+      - /var/run/docker.sock:/var/run/docker.sock
+      
     # Ports mapping between host and container
     ports:
       # Mapping port 7575 of the host to port 7575 of the container


### PR DESCRIPTION
you forgot `/var/run/docker.sock` in volumes added it for you

Without the above volume the following enabled will not work. hence adding the above volume.
![image](https://github.com/bigbeartechworld/big-bear-casaos/assets/145787423/a6d76b4f-3507-43b6-ae30-e870d67613b9)
![image](https://github.com/bigbeartechworld/big-bear-casaos/assets/145787423/c49ffb91-d941-4044-8a46-523b50f3b655)

as shown below now working with volume
![image](https://github.com/bigbeartechworld/big-bear-casaos/assets/145787423/0c85324f-1d9c-4f1d-9060-99a385175979)
