### PR TITLE
update Immich to v1.87.0

### DIFF
--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # Main Immich Server service configuration
   immich-server:
     container_name: immich-server # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v1.86.0 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v1.87.0 # Image to be used
     command: ["start.sh", "immich"] # Command to be executed upon container start
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/upload:/usr/src/app/upload
@@ -28,7 +28,7 @@ services:
   # Configuration for the Immich Microservices
   immich-microservices:
     container_name: immich-microservices # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v1.86.0 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v1.87.0 # Image to be used
     # extends:  # Feature to use configuration from another service (currently commented out)
     #   file: hwaccel.yml
     #   service: hwaccel
@@ -52,7 +52,7 @@ services:
   # Configuration for Immich Machine Learning service
   immich-machine-learning:
     container_name: immich-machine-learning # Name of the running container
-    image: ghcr.io/immich-app/immich-machine-learning:v1.86.0 # Image to be used
+    image: ghcr.io/immich-app/immich-machine-learning:v1.87.0 # Image to be used
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/model-cache:/cache
     environment: # Setting environment variables
@@ -67,7 +67,7 @@ services:
   # Configuration for the Immich Web service
   immich-web:
     container_name: immich-web # Name of the running container
-    image: ghcr.io/immich-app/immich-web:v1.86.0 # Image to be used
+    image: ghcr.io/immich-app/immich-web:v1.87.0 # Image to be used
     restart: always # Policy to always restart the container if it stops
 
   # Configuration for Typesense service
@@ -105,7 +105,7 @@ services:
   # Configuration for Immich Proxy service
   immich-proxy:
     container_name: immich-proxy # Name of the running container
-    image: ghcr.io/immich-app/immich-proxy:v1.86.0 # Image to be used
+    image: ghcr.io/immich-app/immich-proxy:v1.87.0 # Image to be used
     environment: # Setting environment variables
       # Make sure these values get passed through from the env file
       IMMICH_SERVER_URL: http://immich-server:3001

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you have a suggestion for an app, please post in the [BigBearCommunity](https
 | Homer                    | v23.10.1       |                                                                                                                     |
 | Homarr                   | 0.13.4         | [YouTube Video](https://youtu.be/H4rzZNO47Uk)                                                                       |
 | Homepage                 | v0.7.4         |                                                                                                                     |
-| Immich                   | v1.86.0        |                                                                                                                     |
+| Immich                   | v1.87.0        |                                                                                                                     |
 | Mailpit                  | v1.7           |                                                                                                                     |
 | MIND                     | latest         |                                                                                                                     |
 | Mumble Server            | v1.4.230-6     |                                                                                                                     |


### PR DESCRIPTION
> [!NOTE] 
> **The next release will have a different `docker-compose` file :**
> This release is the final version where we bid farewell to the `immich-web` and `immich-proxy` containers. Starting in the next release, the two containers will be consolidated into the `immich-server` container for easier deployment and maintenance.

