### PR TITLE
Update docker-compose.yml to support arm64

### DIFF
--- a/Apps/dashdot/docker-compose.yml
+++ b/Apps/dashdot/docker-compose.yml
@@ -29,6 +29,7 @@ x-casaos:
   architectures:
     - amd64
     - arm
+    - arm64
   # Main service of the application
   main: app
   # Detailed description of the application


### PR DESCRIPTION
The current image supports arm64, but the docker file is not set for this.