### PR TITLE
fixed wrong semaphore version

### DIFF
--- a/Apps/semaphore/config.json
+++ b/Apps/semaphore/config.json
@@ -1,6 +1,6 @@
 {
   "id": "semaphore",
-  "version": "2.19.10",
+  "version": "2.10.22",
   "image": "semaphoreui/semaphore",
   "youtube": "",
   "docs_link": "",

--- a/Apps/semaphore/docker-compose.yml
+++ b/Apps/semaphore/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-semaphore
 
     # Image to be used for the container
-    image: semaphoreui/semaphore:v2.19.10
+    image: semaphoreui/semaphore:v2.10.22
 
     # Container restart policy
     restart: unless-stopped


### PR DESCRIPTION
semaphore v2.19.10 do not exist in the docker registry, it was a typo that was mistakenly published by the developer (https://hub.docker.com/r/semaphoreui/semaphore/tags?page=&page_size=&ordering=&name=v2.19.10)

Published versions available: https://hub.docker.com/r/semaphoreui/semaphore/tags

ref: https://github.com/semaphoreui/semaphore/issues/2154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Downgraded the Semaphore service image version, which may affect application performance and reliability.
	- Updated the application version number in the configuration file to reflect the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->