### PR TITLE
Update RomM docker-compose.yml to 3.5.0

### DIFF
--- a/Apps/Romm/docker-compose.yml
+++ b/Apps/Romm/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # Service name: big-bear-romm
   # The `big-bear-romm` service definition
   big-bear-romm:
-    image: rommapp/romm:3.4.0 # Docker image for the application
+    image: rommapp/romm:3.5.0 # Docker image for the application
     container_name: big-bear-romm
     environment:
       - DB_HOST=big-bear-rommdb # Hostname of the MariaDB container


### PR DESCRIPTION
chore: update romm image to [3.5.0](https://github.com/rommapp/romm/releases/tag/3.5.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the Docker image for the `big-bear-romm` service, potentially introducing new features and performance improvements.
- **Bug Fixes**
	- The update may include bug fixes associated with the newer image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->