### PR TITLE
✨ feat(docker-compose): add tips section for cal.com

### DIFF
--- a/Apps/calcom/docker-compose.yml
+++ b/Apps/calcom/docker-compose.yml
@@ -197,3 +197,8 @@ x-casaos:
   category: BigBearCasaOS
   # Port mapping information
   port_map: "3000"
+  # Tips for the application
+  tips:
+    before_install:
+      en_us: |
+        Read this before installing: https://community.bigbeartechworld.com/t/added-cal-com-to-bigbearcasaos/1873#p-3510-documentation-4


### PR DESCRIPTION
Adds a new `tips` section in the `docker-compose.yml` file for the
cal.com application. This section includes a `before_install` tip
that provides a link to the documentation for users to read before
installing the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `tips` section in the configuration to provide installation guidance for Cal.com on BigBearCasaOS.
	- Added a `before_install` key with a link to relevant documentation, enhancing user experience and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->