### PR TITLE
🚀 feat(owncloud): add installation tips to docker-compose

### DIFF
--- a/Apps/owncloud/docker-compose.yml
+++ b/Apps/owncloud/docker-compose.yml
@@ -209,3 +209,8 @@ x-casaos:
   category: BigBearCasaOS
   # Port mapping information
   port_map: "8080"
+  # Tips for the application
+  tips:
+    before_install:
+      en_us: |
+        Read this before installing: https://community.bigbeartechworld.com/t/added-owncloud-to-bigbearcasaos/1874#p-3512-documentation-4


### PR DESCRIPTION
Adds a new section to the owncloud docker-compose file to provide
users with a link to important installation documentation before
they install the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `tips` section in the configuration to provide installation guidance for OwnCloud.
	- Added a `before_install` key directing users to documentation for a smoother installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->