### PR TITLE
🛠️ feat(nextcloud): Increase PHP memory and upload limits

### DIFF
--- a/Apps/nextcloud/docker-compose.yml
+++ b/Apps/nextcloud/docker-compose.yml
@@ -31,7 +31,8 @@ services:
       - NEXTCLOUD_ADMIN_PASSWORD=casaos
       - TRUSTED_PROXIES=
       - OVERWRITEPROTOCOL=http
-      - PHP_UPLOAD_LIMIT=1024G
+      - PHP_MEMORY_LIMIT=1024M
+      - PHP_UPLOAD_LIMIT=1024M
     # Specify the dependencies
     depends_on:
       db-nextcloud:


### PR DESCRIPTION
Increase the PHP memory limit to 1024M and the upload limit to 1024M
to ensure Nextcloud can handle larger files and data sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new memory limit for PHP processes to enhance performance.
  
- **Bug Fixes**
	- Reduced the maximum file upload size from 1 terabyte to 1 gigabyte to improve resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->