### PR TITLE
✨ feat(filebrowser): add user/group env vars

### DIFF
--- a/Apps/filebrowser/docker-compose.yml
+++ b/Apps/filebrowser/docker-compose.yml
@@ -45,6 +45,13 @@ services:
       - "8080:80"
 
     x-casaos: # CasaOS specific configuration
+      envs:
+        - container: "PUID"
+          description:
+            en_us: "User ID"
+        - container: "PGID"
+          description:
+            en_us: "Group ID"
       volumes:
         - container: /srv/app-data
           description:


### PR DESCRIPTION
Adds the `PUID` and `PGID` environment variables to the Filebrowser
service in the Docker Compose file. This allows users to specify the
user ID and group ID to use for the Filebrowser container, enabling
better file permissions management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new environment variable configurations for user and group IDs in the file browser service, enhancing permission management.
	- Improved clarity with descriptive labels for the new environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->