### PR TITLE
✨ feat: Add config volume mapping for Filebrowser

### DIFF
--- a/Apps/filebrowser/config.json
+++ b/Apps/filebrowser/config.json
@@ -1,6 +1,6 @@
 {
   "id": "filebrowser",
-  "version": "v2-s6",
+  "version": "v2.31.1-s6",
   "image": "filebrowser/filebrowser",
   "youtube": "",
   "docs_link": "",

--- a/Apps/filebrowser/docker-compose.yml
+++ b/Apps/filebrowser/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-filebrowser
 
     # Image to be used for the container
-    image: filebrowser/filebrowser:v2-s6
+    image: filebrowser/filebrowser:v2.31.1-s6
 
     # Container restart policy
     restart: unless-stopped

--- a/Apps/filebrowser/docker-compose.yml
+++ b/Apps/filebrowser/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       - /DATA/media:/srv/media
       # Volume mapping for the database files for filebrowser
       - /DATA/AppData/$AppID/data/db:/database
+      # Volume mapping for the config files for filebrowser
+      - /DATA/AppData/$AppID/data/config:/config
 
     # Ports mapping between host and container
     ports:
@@ -71,6 +73,9 @@ services:
         - container: /database
           description:
             en_us: "Container Path: /database"
+        - container: /config
+          description:
+            en_us: "Container Path: /config"
       ports:
         - container: "80"
           description:


### PR DESCRIPTION
This commit adds a new volume mapping for the Filebrowser config files
in the `docker-compose.yml` file. This allows the Filebrowser
configuration to be stored and persisted outside of the container,
making it easier to manage and maintain the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new volume mapping for configuration files, enhancing the filebrowser's configurability.
  
- **Documentation**
	- Updated documentation to include details about the new `/config` directory mapping for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->