### PR TITLE
✨ feat(linkstack): add YouTube link to config

### DIFF
--- a/Apps/linkstack/config.json
+++ b/Apps/linkstack/config.json
@@ -2,7 +2,7 @@
   "id": "linkstack",
   "version": "V4",
   "image": "linkstackorg/linkstack",
-  "youtube": "",
+  "youtube": "https://youtu.be/1KgFlCsItro",
   "docs_link": "",
   "big_bear_cosmos_youtube": ""
 }


### PR DESCRIPTION
Adds a YouTube link to the `linkstack` app's configuration.
This allows users to access a video demonstration of the app.