### PR TITLE
♻️ chore(docker): update Minio and Postgres containers

### DIFF
--- a/Apps/reactive-resume/docker-compose.yml
+++ b/Apps/reactive-resume/docker-compose.yml
@@ -78,7 +78,7 @@ services:
 
   # Database (Postgres)
   postgres:
-    container_name: big-bear-reactive-resume-postgres
+    container_name: big-bear-reactive-resume-db
     image: postgres:15-alpine
     restart: unless-stopped
     volumes:
@@ -98,7 +98,7 @@ services:
   # Storage (for image uploads)
   minio:
     container_name: big-bear-reactive-resume-minio
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-09-13T20-26-02Z-cpuv1
     command: ["server", "/data"]
     restart: unless-stopped
     ports:


### PR DESCRIPTION
- Updates the Minio container to the latest version (RELEASE.2024-09-13T20-26-02Z-cpuv1)
- Renames the Postgres container from `big-bear-reactive-resume-postgres` to `big-bear-reactive-resume-db`
- These changes ensure the application is using the latest versions of the supporting services, and improve the clarity of the container names.