### PR TITLE
🔖 feat: Rename Immich server, redis, and database containers

### DIFF
--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -15,12 +15,12 @@ services:
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/big-bear-immich/upload:/usr/src/app/upload
     environment: # Setting environment variables
-      DB_HOSTNAME: immich-postgres
+      DB_HOSTNAME: big-bear-immich-postgres
       DB_USERNAME: casaos
       DB_PASSWORD: casaos
       DB_DATABASE_NAME: immich
       DB_PORT: "5432"
-      REDIS_HOSTNAME: immich-redis
+      REDIS_HOSTNAME: big-bear-immich-redis
     depends_on: # Dependencies to ensure the order of service startup
       - redis
       - database

--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       DB_PORT: "5432"
       REDIS_HOSTNAME: big-bear-immich-redis
     depends_on: # Dependencies to ensure the order of service startup
-      - redis
-      - database
+      - big-bear-immich-redis
+      - big-bear-immich-database
     restart: unless-stopped # Policy to restart unless stopped
 
     x-casaos: # CasaOS specific configuration

--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -4,8 +4,8 @@ name: big-bear-immich-without-machine-learning
 # Service definitions for the big-bear-immich-without-machine-learning application
 services:
   # Main Immich Server service configuration
-  immich-server:
-    container_name: immich-server # Name of the running container
+  big-bear-immich-server:
+    container_name: big-bear-immich-server # Name of the running container
     image: ghcr.io/immich-app/immich-server:v1.115.0 # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
@@ -56,14 +56,14 @@ services:
             en_us: "Container Port: 3001"
 
   # Configuration for Redis service
-  redis:
-    container_name: immich-redis # Name of the running container
+  big-bear-immich-redis:
+    container_name: big-bear-immich-redis # Name of the running container
     image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3 # Image to be used
     restart: always # Policy to always restart the container if it stops
 
   # Configuration for Database service
-  database:
-    container_name: immich-postgres # Name of the running container
+  big-bear-immich-database:
+    container_name: big-bear-immich-postgres # Name of the running container
     image: tensorchord/pgvecto-rs:pg14-v0.2.0 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos

--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-immich-without-machine-learning
 # Service definitions for the big-bear-immich-without-machine-learning application
 services:
   # Main Immich Server service configuration
-  big-bear-immich-server:
+  immich-server:
     container_name: big-bear-immich-server # Name of the running container
     image: ghcr.io/immich-app/immich-server:v1.115.0 # Image to be used
     # extends:
@@ -22,8 +22,8 @@ services:
       DB_PORT: "5432"
       REDIS_HOSTNAME: big-bear-immich-redis
     depends_on: # Dependencies to ensure the order of service startup
-      - big-bear-immich-redis
-      - big-bear-immich-database
+      - redis
+      - database
     restart: unless-stopped # Policy to restart unless stopped
 
     x-casaos: # CasaOS specific configuration
@@ -56,13 +56,13 @@ services:
             en_us: "Container Port: 3001"
 
   # Configuration for Redis service
-  big-bear-immich-redis:
+  redis:
     container_name: big-bear-immich-redis # Name of the running container
     image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3 # Image to be used
     restart: always # Policy to always restart the container if it stops
 
   # Configuration for Database service
-  big-bear-immich-database:
+  database:
     container_name: big-bear-immich-postgres # Name of the running container
     image: tensorchord/pgvecto-rs:pg14-v0.2.0 # Image to be used
     environment: # Setting environment variables

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -20,11 +20,11 @@ services:
       DB_PASSWORD: casaos
       DB_DATABASE_NAME: immich
       DB_PORT: "5432"
-      REDIS_HOSTNAME: immich-redis
+      REDIS_HOSTNAME: big-bear-immich-redis
       IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning:3003
     depends_on: # Dependencies to ensure the order of service startup
       - big-bear-immich-redis
-      - big-bear-immich-database
+      - big-bear-immich-postgres
     restart: unless-stopped # Policy to restart unless stopped
 
     # Networks to be attached to the container
@@ -116,7 +116,7 @@ services:
       - big_bear_immich_network # Connects the container to a defined network
 
   # Configuration for Database service
-  big-bear-immich-database:
+  big-bear-immich-postgres:
     container_name: big-bear-immich-postgres # Name of the running container
     image: tensorchord/pgvecto-rs:pg14-v0.2.0 # Image to be used
     environment: # Setting environment variables

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/upload:/usr/src/app/upload
     environment: # Setting environment variables
-      DB_HOSTNAME: immich-postgres
+      DB_HOSTNAME: big-bear-immich-postgres
       DB_USERNAME: casaos
       DB_PASSWORD: casaos
       DB_DATABASE_NAME: immich
@@ -23,8 +23,8 @@ services:
       REDIS_HOSTNAME: immich-redis
       IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning:3003
     depends_on: # Dependencies to ensure the order of service startup
-      - redis
-      - database
+      - big-bear-immich-redis
+      - big-bear-immich-database
     restart: unless-stopped # Policy to restart unless stopped
 
     # Networks to be attached to the container
@@ -70,12 +70,12 @@ services:
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/model-cache:/cache
     environment: # Setting environment variables
-      DB_HOSTNAME: immich-postgres
+      DB_HOSTNAME: big-bear-immich-postgres
       DB_USERNAME: casaos
       DB_PASSWORD: casaos
       DB_DATABASE_NAME: casaos
       DB_PORT: 5432
-      REDIS_HOSTNAME: immich-redis
+      REDIS_HOSTNAME: big-bear-immich-redis
     restart: unless-stopped # Policy to restart unless stopped
 
     # Networks to be attached to the container

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -4,8 +4,8 @@ name: big-bear-immich
 # Service definitions for the big-bear-immich application
 services:
   # Main Immich Server service configuration
-  immich-server:
-    container_name: immich-server # Name of the running container
+  big-bear-immich-server:
+    container_name: big-bear-immich-server # Name of the running container
     image: ghcr.io/immich-app/immich-server:v1.115.0 # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
@@ -64,8 +64,8 @@ services:
             en_us: "Container Port: 3001"
 
   # Configuration for Immich Machine Learning service
-  immich-machine-learning:
-    container_name: immich-machine-learning # Name of the running container
+  big-bear-immich-machine-learning:
+    container_name: big-bear-immich-machine-learning # Name of the running container
     image: ghcr.io/immich-app/immich-machine-learning:v1.115.0 # Image to be used
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/model-cache:/cache
@@ -108,16 +108,16 @@ services:
             en_us: "Container Path: /cache"
 
   # Configuration for Redis service
-  redis:
-    container_name: immich-redis # Name of the running container
+  big-bear-immich-redis:
+    container_name: big-bear-immich-redis # Name of the running container
     image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3 # Image to be used
     restart: always # Policy to always restart the container if it stops
     networks:
       - big_bear_immich_network # Connects the container to a defined network
 
   # Configuration for Database service
-  database:
-    container_name: immich-postgres # Name of the running container
+  big-bear-immich-database:
+    container_name: big-bear-immich-postgres # Name of the running container
     image: tensorchord/pgvecto-rs:pg14-v0.2.0 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-immich
 # Service definitions for the big-bear-immich application
 services:
   # Main Immich Server service configuration
-  big-bear-immich-server:
+  immich-server:
     container_name: big-bear-immich-server # Name of the running container
     image: ghcr.io/immich-app/immich-server:v1.115.0 # Image to be used
     # extends:
@@ -23,8 +23,8 @@ services:
       REDIS_HOSTNAME: big-bear-immich-redis
       IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning:3003
     depends_on: # Dependencies to ensure the order of service startup
-      - big-bear-immich-redis
-      - big-bear-immich-postgres
+      - redis
+      - database
     restart: unless-stopped # Policy to restart unless stopped
 
     # Networks to be attached to the container
@@ -64,7 +64,7 @@ services:
             en_us: "Container Port: 3001"
 
   # Configuration for Immich Machine Learning service
-  big-bear-immich-machine-learning:
+  immich-machine-learning:
     container_name: big-bear-immich-machine-learning # Name of the running container
     image: ghcr.io/immich-app/immich-machine-learning:v1.115.0 # Image to be used
     volumes: # Mounting directories for persistent data storage
@@ -108,7 +108,7 @@ services:
             en_us: "Container Path: /cache"
 
   # Configuration for Redis service
-  big-bear-immich-redis:
+  redis:
     container_name: big-bear-immich-redis # Name of the running container
     image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3 # Image to be used
     restart: always # Policy to always restart the container if it stops
@@ -116,7 +116,7 @@ services:
       - big_bear_immich_network # Connects the container to a defined network
 
   # Configuration for Database service
-  big-bear-immich-postgres:
+  database:
     container_name: big-bear-immich-postgres # Name of the running container
     image: tensorchord/pgvecto-rs:pg14-v0.2.0 # Image to be used
     environment: # Setting environment variables
@@ -160,7 +160,7 @@ x-casaos:
   architectures: # Supported CPU architectures
     - amd64
     - arm64
-  main: big-bear-immich-server # Main service of the application
+  main: immich-server # Main service of the application
   description: # Description in different languages
     en_us: Self-hosted photo and video storage.
   tagline: # Short description or tagline in different languages

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -160,7 +160,7 @@ x-casaos:
   architectures: # Supported CPU architectures
     - amd64
     - arm64
-  main: immich-server # Main service of the application
+  main: big-bear-immich-server # Main service of the application
   description: # Description in different languages
     en_us: Self-hosted photo and video storage.
   tagline: # Short description or tagline in different languages


### PR DESCRIPTION
The changes made in this commit are:

- Renamed the `immich-server` container to `big-bear-immich-server` in both `immich-without-machine-learning` and `immich` docker-compose files.
- Renamed the `redis` container to `big-bear-immich-redis` in both `immich-without-machine-learning` and `immich` docker-compose files.
- Renamed the `database` container to `big-bear-immich-database` in both `immich-without-machine-learning` and `immich` docker-compose files.

These changes were made to differentiate the Immich containers from other services running on the host, improving the overall organization and clarity of the deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Service names updated for clarity and consistency across the application, now prefixed with "big-bear-".
		- Immich server, Redis, database, and machine learning services have been renamed accordingly.

These changes enhance the organization of service identifiers without altering existing functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->