### PR TITLE
fix: fix invalid compose project

### DIFF
--- a/Apps/owncloud/docker-compose.yml
+++ b/Apps/owncloud/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - ${APP_DATA_DIR}/data/mysql:/var/lib/mysql
+      - /DATA/AppData/$AppID/data/mysql:/var/lib/mysql
     networks:
       - big_bear_owncloud_network
 
@@ -162,7 +162,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - ${APP_DATA_DIR}/data/redis:/data
+      - /DATA/AppData/$AppID/data/redis:/data
     networks:
       - big_bear_owncloud_network
 


### PR DESCRIPTION
fix it 
```
2024-09-25T15:42:07.980+0800    info    failed to parse compose app - contact the contributor of this app to fix it     {"error": "service \"big-bear-owncloud-db\" refers to undefined volume ${APP_DATA_DIR}/data/mysql: invalid compose project", "errorVerbose": "invalid compose project\nservice \"big-bear-owncloud-db\" refers to undefined volume ${APP_DATA_DIR}/data/mysql\ngithub.com/compose-spec/compose-go/loader.checkConsistency\n\t/DATA/go/pkg/mod/github.com/compose-spec/compose-go@v1.20.2/loader/validate.go:87\ngithub.com/compose-spec/compose-go/loader.load\n\t/DATA/go/pkg/mod/github.com/compose-spec/compose-go@v1.20.2/loader/loader.go:390\ngithub.com/compose-spec/compose-go/loader.LoadWithContext\n\t/DATA/go/pkg/mod/github.com/compose-spec/compose-go@v1.20.2/loader/loader.go:250\ngithub.com/compose-spec/compose-go/loader.Load\n\t/DATA/go/pkg/mod/github.com/compose-spec/compose-go@v1.20.2/loader/loader.go:214\ngithub.com/IceWhaleTech/CasaOS-AppManagement/service.NewComposeAppFromYAML\n\t/DATA/Codes/CasaOS-AppManagement/service/compose_app.go:962\ngithub.com/IceWhaleTech/CasaOS-AppManagement/service.BuildCatalog.func1\n\t/DATA/Codes/CasaOS-AppManagement/service/appstore.go:393\npath/filepath.walkDir\n\t/opt/bin/go/src/path/filepath/path.go:310\npath/filepath.walkDir\n\t/opt/bin/go/src/path/filepath/path.go:332\npath/filepath.WalkDir\n\t/opt/bin/go/src/path/filepath/path.go:400\ngithub.com/IceWhaleTech/CasaOS-AppManagement/service.BuildCatalog\n\t/DATA/Codes/CasaOS-AppManagement/service/appstore.go:370\ngithub.com/IceWhaleTech/CasaOS-AppManagement/service.(*appStore).UpdateCatalog\n\t/DATA/Codes/CasaOS-AppManagement/service/appstore.go:163\ngithub.com/IceWhaleTech/CasaOS-AppManagement/service.(*AppStoreManagement).UpdateCatalog\n\t/DATA/Codes/CasaOS-AppManagement/service/appstore_management.go:436\nmain.main.func2\n\t/DATA/Codes/CasaOS-AppManagement/main.go:94\ngithub.com/robfig/cron/v3.FuncJob.Run\n\t/DATA/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:136\ngithub.com/robfig/cron/v3.(*Cron).startJob.func1\n\t/DATA/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:312\nruntime.goexit\n\t/opt/bin/go/src/runtime/asm_amd64.s:1700", "composeFile": "/var/lib/casaos/appstore/github.com/2a1238d53212bfce4e8f861dcb8ef3fe/big-bear-casaos-master/Apps/owncloud/docker-compose.yml", "func": "service.BuildCatalog.func1", "file": "/DATA/Codes/CasaOS-AppManagement/service/appstore.go", "line": 395}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated volume paths for MySQL and Redis services to ensure proper data storage locations.

These changes enhance the reliability of data handling within the application, ensuring that services function correctly with the specified paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->