### PR TITLE
✨ feat(2fauth): Add arm64 architecture support

### DIFF
--- a/Apps/2fauth/docker-compose.yml
+++ b/Apps/2fauth/docker-compose.yml
@@ -44,7 +44,7 @@ x-casaos:
   # Supported CPU architectures for this application
   architectures:
     - amd64
-    - arm
+    - arm64
   # Main service for this application
   main: app
   # Detailed description for the application


### PR DESCRIPTION
Adds support for the arm64 CPU architecture to the 2fauth
application, allowing it to run on a wider range of devices.
This change is made to improve the application's
compatibility and accessibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated support for 64-bit ARM architecture in the application, enhancing compatibility with modern hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->