### PR TITLE
🐳 feat(tududi): remove arm64 architecture support

### DIFF
--- a/Apps/tududi/docker-compose.yml
+++ b/Apps/tududi/docker-compose.yml
@@ -62,7 +62,6 @@ x-casaos:
   # Supported CPU architectures for the application
   architectures:
     - amd64
-    - arm64
   # Main service of the application
   main: big-bear-tududi
   description:


### PR DESCRIPTION
Removes the arm64 architecture support from the tududi
application's docker-compose configuration. This change is made
to simplify the deployment process and reduce the maintenance
overhead, as the arm64 architecture is not a primary target for
this application.