### PR TITLE
✨ feat: Add Nextcloud with SMB client setup

### DIFF
--- a/Apps/nextcloud-with-smbclient/config.json
+++ b/Apps/nextcloud-with-smbclient/config.json
@@ -1,0 +1,8 @@
+{
+  "id": "nextcloud-with-smbclient",
+  "version": "0.0.1",
+  "image": "bigbeartechworld/big-bear-nextcloud-with-smbclient",
+  "youtube": "",
+  "docs_link": "",
+  "big_bear_cosmos_youtube": ""
+}

--- a/Apps/nextcloud-with-smbclient/docker-compose.yml
+++ b/Apps/nextcloud-with-smbclient/docker-compose.yml
@@ -1,0 +1,216 @@
+# Configuration for nextcloud-smb setup
+
+# Name of the big-bear-nextcloud-smb application
+name: big-bear-nextcloud-smb
+
+# Service definitions for the big-bear-nextcloud-smb application
+services:
+  # Service name: app
+  # The `app` service definition
+  big-bear-nextcloud-smb:
+    # Define the container name
+    container_name: big-bear-nextcloud-smb
+    # Use the nextcloud image from the official Docker Hub
+    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:0.0.1
+    # Restart the container unless stopped
+    restart: unless-stopped
+    # Map port 7580 on the host to port 80 on the container
+    ports:
+      - 7580:80
+    # Mount the /DATA/AppData/$AppID/html directory on the host to /var/www/html in the container
+    volumes:
+      - /DATA/AppData/$AppID/html:/var/www/html
+    # Set environment variables for the container
+    environment:
+      - POSTGRES_HOST=big-bear-nextcloud-smb-db
+      - REDIS_HOST=big-bear-nextcloud-smb-redis
+      - POSTGRES_PASSWORD=casaos
+      - POSTGRES_USER=casaos
+      - POSTGRES_DB=nextcloud
+      - NEXTCLOUD_ADMIN_USER=casaos
+      - NEXTCLOUD_ADMIN_PASSWORD=casaos
+      - TRUSTED_PROXIES=
+      - OVERWRITEPROTOCOL=http
+      - PHP_MEMORY_LIMIT=1024M
+      - PHP_UPLOAD_LIMIT=1024M
+    # Specify the dependencies
+    depends_on:
+      big-bear-nextcloud-smb-db:
+        condition: service_healthy
+      big-bear-nextcloud-smb-redis:
+        condition: service_healthy
+
+    # Define the network
+    networks:
+      - big_bear_nextcloud_network
+
+    x-casaos: # CasaOS specific configuration
+      volumes:
+        - container: /var/www/html
+          description:
+            en_us: "Container Path: /var/www/html"
+      envs:
+        - container: POSTGRES_HOST
+          description:
+            en_us: Database host
+        - container: REDIS_HOST
+          description:
+            en_us: Redis host
+        - container: POSTGRES_PASSWORD
+          description:
+            en_us: Database password
+        - container: POSTGRES_USER
+          description:
+            en_us: Database user
+        - container: POSTGRES_DB
+          description:
+            en_us: Database type
+        - container: NEXTCLOUD_ADMIN_USER
+          description:
+            en_us: Nextcloud admin user
+        - container: NEXTCLOUD_ADMIN_PASSWORD
+          description:
+            en_us: Nextcloud admin password
+        - container: TRUSTED_PROXIES
+          description:
+            en_us: Trusted proxies
+        - container: OVERWRITEPROTOCOL
+          description:
+            en_us: Overwrite protocol
+        - container: PHP_UPLOAD_LIMIT
+          description:
+            en_us: PHP upload limit
+      ports:
+        - container: "7580"
+          description:
+            en_us: "Container Port: 7580"
+
+  # Define the database container for Nextcloud
+  big-bear-nextcloud-smb-db:
+    container_name: big-bear-nextcloud-smb-db
+    image: postgres:14.2
+    restart: unless-stopped
+    volumes:
+      - /DATA/AppData/$AppID/pgdata:/var/lib/postgresql/data # Mount the PostgreSQL data directory
+    environment:
+      - POSTGRES_PASSWORD=casaos # Set the PostgreSQL password
+      - POSTGRES_USER=casaos # Set the PostgreSQL username
+      - POSTGRES_DB=nextcloud # Set the name of the Nextcloud database
+    networks:
+      - big_bear_nextcloud_network # Connect to the Nextcloud network
+
+    # Healthcheck configuration for the database service
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U casaos -d nextcloud"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+    x-casaos:
+      volumes:
+        - container: /var/lib/postgresql/data
+          description:
+            en_us: "Container Path: /var/lib/postgresql/data"
+      envs:
+        - container: POSTGRES_PASSWORD
+          description:
+            en_us: Database password
+        - container: POSTGRES_USER
+          description:
+            en_us: Database user
+        - container: POSTGRES_DB
+          description:
+            en_us: Database type
+
+  # Redis configuration for Nextcloud
+
+  big-bear-nextcloud-smb-redis:
+    container_name: big-bear-nextcloud-smb-redis
+    user: "1000:1000"
+    image: redis:6.2.6
+    restart: on-failure
+    volumes:
+      - "/DATA/AppData/$AppID/redis:/data" # Mount the Redis data directory
+    networks:
+      - big_bear_nextcloud_network # Connect to the Nextcloud network
+
+    # Healthcheck configuration for the Redis service
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+    x-casaos:
+      volumes:
+        - container: /data
+          description:
+            en_us: "Container Path: /data"
+      ports:
+        - container: "6379"
+          description:
+            en_us: "Container Port: 6379"
+
+  big-bear-nextcloud-smb-cron:
+    container_name: big-bear-nextcloud-smb-cron
+    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:0.0.1
+    restart: on-failure
+    volumes:
+      - /DATA/AppData/$AppID/html:/var/www/html
+    entrypoint: /cron.sh
+    # Specify the dependencies
+    depends_on:
+      big-bear-nextcloud-smb-db:
+        condition: service_healthy
+      big-bear-nextcloud-smb-redis:
+        condition: service_healthy
+    networks:
+      - big_bear_nextcloud_network # Connect to the Nextcloud network
+
+    x-casaos:
+      volumes:
+        - container: /var/www/html
+          description:
+            en_us: "Container Path: /var/www/html"
+
+# Network definition for the big-bear-nextcloud application
+networks:
+  big_bear_nextcloud_network:
+    driver: bridge
+
+# CasaOS specific configuration
+x-casaos:
+  # Supported CPU architectures for the application
+  architectures:
+    - amd64
+    - arm64
+  # Main service of the application
+  main: big-bear-nextcloud-smb
+  description:
+    # Description in English
+    en_us: Nextcloud puts your data at your fingertips, under your control. Store your documents, calendar, contacts and photos on a server at home, at one of our providers or in a data center you trust.
+  tagline:
+    en_us: The productivity platform that keeps you in control
+  # Developer's name or identifier
+  developer: "nextcloud"
+  # Author of this configuration
+  author: BigBearTechWorld
+  # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextcloud.png
+  # Thumbnail image (currently empty)
+  thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg
+  screenshot_link:
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-3.png
+  title:
+    # Title in English
+    en_us: Nextcloud with SMB
+  # Application category
+  category: BigBearCasaOS
+  # Port mapping information
+  port_map: "7580"
+  tips:
+    before_install:
+      en_us: |
+        Read the [Nextcloud installation guide](https://community.bigbeartechworld.com/t/added-nextcloud-to-bigbearcasaos/455?u=dragonfire1119)


### PR DESCRIPTION
This commit introduces a new Docker Compose configuration for a Nextcloud
setup with an SMB client. The key changes include:

- Defines the `big-bear-nextcloud-smb` application with a container for the
  Nextcloud app, a PostgreSQL database, and a Redis cache.
- Configures the Nextcloud app container with environment variables for the
  database, Redis, and other settings.
- Mounts the Nextcloud data directory on the host to persist data.
- Includes healthchecks for the database and Redis services to ensure
  they are running correctly.
- Provides CasaOS-specific configuration, including container paths and
  environment variable descriptions.