### PR TITLE
🔥 feat(open-webui): add installation tips for Open WebUI

### DIFF
--- a/Apps/open-webui/docker-compose.yml
+++ b/Apps/open-webui/docker-compose.yml
@@ -70,3 +70,8 @@ x-casaos:
   category: BigBearCasaOS
   # Port mapping information
   port_map: "8080"
+  # Tips for installation
+  tips:
+    before_install:
+      en_us: |
+        Read this before installing: https://community.bigbeartechworld.com/t/added-open-webui-to-bigbearcasaos/1263#p-2265-documentation-3


### PR DESCRIPTION
Adds a new `tips` section to the Open WebUI service in the
docker-compose.yml file. This includes a `before_install` entry with
a link to the community documentation for important information
users should read before installing Open WebUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `tips` section in the configuration to provide installation guidance.
	- Included a `before_install` key with a link to relevant documentation for easier setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->