### PR TITLE
✨ fix(compose): update Immich container port to 2283

### DIFF
--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
     ports: # Mapping ports from the host OS to the container
-      - 2283:3001
+      - 2283:2283
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/big-bear-immich/upload:/usr/src/app/upload
     environment: # Setting environment variables
@@ -51,9 +51,9 @@ services:
           description:
             en_us: "Container Path: /usr/src/app/upload"
       ports:
-        - container: "3001"
+        - container: "2283"
           description:
-            en_us: "Container Port: 3001"
+            en_us: "Container Port: 2283"
 
   # Configuration for Redis service
   redis:

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
     ports: # Mapping ports from the host OS to the container
-      - 2283:3001
+      - 2283:2283
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/upload:/usr/src/app/upload
     environment: # Setting environment variables
@@ -59,9 +59,9 @@ services:
           description:
             en_us: "Container Path: /usr/src/app/upload"
       ports:
-        - container: "3001"
+        - container: "2283"
           description:
-            en_us: "Container Port: 3001"
+            en_us: "Container Port: 2283"
 
   # Configuration for Immich Machine Learning service
   immich-machine-learning:


### PR DESCRIPTION
This pull request updates the container port in the docker-compose.yml files for both the `immich` and `immich-without-machine-learning` services to use port 2283 instead of 3001. This change is necessary to ensure the correct port is used for the Immich application.