### PR TITLE
Add MyMPD Service

### DIFF
--- a/Apps/mympd/config.json
+++ b/Apps/mympd/config.json
@@ -1,0 +1,8 @@
+{
+  "id": "mympd",
+  "version": "latest",
+  "image": "ghcr.io/jcorporation/mympd/mympd",
+  "youtube": "",
+  "docs_link": "",
+  "big_bear_cosmos_youtube": ""
+}

--- a/Apps/mympd/config.json
+++ b/Apps/mympd/config.json
@@ -1,6 +1,6 @@
 {
   "id": "mympd",
-  "version": "latest",
+  "version": "18.2.2",
   "image": "ghcr.io/jcorporation/mympd/mympd",
   "youtube": "",
   "docs_link": "",

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -42,7 +42,7 @@ x-casaos:
     en_us: mympd # Title in English
   category: BigBearCasaOS # Category of the application
   port_map: "8080" # Port mapping information for the service
-  scheme: https # Scheme for the service
+  scheme: http # Scheme for the service
   tips:
     before_install:
       en_us: |

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -31,7 +31,7 @@ x-casaos:
     - armv7
   main: mympd # Specifies the main service of the application
   description:
-    en_us: myMPD is a standalone and mobile friendly web-based MPD client with a tiny footprint and advanced features.# Description in English
+    en_us: myMPD is a standalone and mobile friendly web-based MPD client with a tiny footprint and advanced features.
   tagline:
     en_us: mpd # Short description or tagline in English
   developer: "jcorporation" # Developer's name or identifier (currently empty)

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -13,13 +13,13 @@ services:
       - MPD_HOST=
       - MPD_PORT=
     volumes:
-      - /run/mpd:/run/mpd
+      - /DATA/AppData/$AppID/run/mpd:/run/mpd
       ## Optional for myGPIOd support
       ## - /run/mygpiod:/run/mygpiod
-      - /docker/mympd/workdir:/var/lib/mympd
-      - /docker/mympd/cachedir:/var/cache/mympd
-      - /var/lib/mpd/music:/var/lib/mpd/music:ro
-      - /var/lib/mpd/playlists:/var/lib/mpd/playlists:ro
+      - /DATA/AppData/$AppID/docker/mympd/workdir:/var/lib/mympd
+      - /DATA/AppData/$AppID/docker/mympd/cachedir:/var/cache/mympd
+      - /DATA/AppData/$AppID/var/lib/mpd/music:/var/lib/mpd/music:ro
+      - /DATA/AppData/$AppID/var/lib/mpd/playlists:/var/lib/mpd/playlists:ro
     restart: unless-stopped
 
 # Global CasaOS specific configuration

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -29,7 +29,7 @@ x-casaos:
     - arm64
     - armv6
     - armv7
-  main: mympd # Specifies the main service of the application
+  main: big-bear-mympd # Specifies the main service of the application
   description:
     en_us: myMPD is a standalone and mobile friendly web-based MPD client with a tiny footprint and advanced features.
   tagline:

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -4,14 +4,15 @@ services:
     image: ghcr.io/jcorporation/mympd/mympd:18.2.2
     container_name: big-bear-mympd
     ports:
-      - 8080:8080
-    user: 1000:1000
+      - ${MYMPD_HTTP_PORT:-8080}:8080
+    user: ${MYMPD_UID:-1000}:${MYMPD_GID:-1000}
     environment:
       - UMASK_SET=022
       - MYMPD_SSL=false
-      - MYMPD_HTTP_PORT=
-      - MPD_HOST=
-      - MPD_PORT=
+      - MYMPD_HTTP_PORT=${MYMPD_HTTP_PORT:-8080}
+      - MPD_HOST=${MPD_HOST:-localhost}
+      - MPD_PORT=${MPD_PORT:-6600}
+      - MYMPD_UID=1000
     volumes:
       - /DATA/AppData/$AppID/run/mpd:/run/mpd
       ## Optional for myGPIOd support

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-mympd # Name of the CasaOS application
 services:
   mympd:
-    image: ghcr.io/jcorporation/mympd/mympd:latest
+    image: ghcr.io/jcorporation/mympd/mympd:18.2.2
     container_name: mympd
     ports:
       - 8080:8080

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -1,0 +1,49 @@
+name: myMPD # Name of the CasaOS application
+services:
+  mympd:
+    image: ghcr.io/jcorporation/mympd/mympd:latest
+    container_name: mympd
+    ports:
+      - 8080:8080
+    user: 1000:1000
+    environment:
+      - UMASK_SET=022
+      - MYMPD_SSL=false
+      - MYMPD_HTTP_PORT=
+      - MPD_HOST=
+      - MPD_PORT=
+    volumes:
+      - /run/mpd:/run/mpd
+      ## Optional for myGPIOd support
+      ## - /run/mygpiod:/run/mygpiod
+      - /docker/mympd/workdir:/var/lib/mympd
+      - /docker/mympd/cachedir:/var/cache/mympd
+      - /var/lib/mpd/music:/var/lib/mpd/music:ro
+      - /var/lib/mpd/playlists:/var/lib/mpd/playlists:ro
+    restart: unless-stopped
+
+# Global CasaOS specific configuration
+x-casaos:
+  architectures: # Supported CPU architectures for the application
+    - amd64
+    - arm64
+    - armv6
+    - armv7
+  main: mympd # Specifies the main service of the application
+  description:
+    en_us: myMPD is a standalone and mobile friendly web-based MPD client with a tiny footprint and advanced features.# Description in English
+  tagline:
+    en_us: mpd # Short description or tagline in English
+  developer: "jcorporation" # Developer's name or identifier (currently empty)
+  author: BigBearTechWorld # Author of this Docker Compose configuration
+  icon: https://jcorporation.github.io/myMPD/assets/mympd-logo.svg # Icon URL for the application
+  thumbnail: "" # Thumbnail image URL
+  title:
+    en_us: mympd # Title in English
+  category: BigBearCasaOS # Category of the application
+  port_map: "8080" # Port mapping information for the service
+  scheme: https # Scheme for the service
+  tips:
+    before_install:
+      en_us: |
+        Check https://jcorporation.github.io/myMPD/010-installation/docker/#docker-compose and https://jcorporation.github.io/myMPD/020-configuration/configuration-files/ for more configuration.

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -35,7 +35,7 @@ x-casaos:
   tagline:
     en_us: mpd # Short description or tagline in English
   developer: "jcorporation" # Developer's name or identifier (currently empty)
-  author: BigBearTechWorld # Author of this Docker Compose configuration
+  author: BigBearCommunity # Author of this Docker Compose configuration
   icon: https://jcorporation.github.io/myMPD/assets/mympd-logo.svg # Icon URL for the application
   thumbnail: "" # Thumbnail image URL
   title:

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -1,4 +1,4 @@
-name: myMPD # Name of the CasaOS application
+name: big-bear-mympd # Name of the CasaOS application
 services:
   mympd:
     image: ghcr.io/jcorporation/mympd/mympd:latest

--- a/Apps/mympd/docker-compose.yml
+++ b/Apps/mympd/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-mympd # Name of the CasaOS application
 services:
   mympd:
     image: ghcr.io/jcorporation/mympd/mympd:18.2.2
-    container_name: mympd
+    container_name: big-bear-mympd
     ports:
       - 8080:8080
     user: 1000:1000


### PR DESCRIPTION
Added MyMPD Service.

MyMPD is a client for the music player daemon. You can fetch lyrics, listen with httpd stream, create scripts… As it is a webclient, it is accessible in any device.

MyMPD: github.com/jcorporation/myMPD

MyMPD documentation on Docker: jcorporation.github.io/myMPD/010-installation/docker/

On my setup, it connects to MPD running on system-level. With proper configuration, can connect to any MPD instance on the network/web.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration file for the myMPD application, enabling easier identification and deployment.
	- Added a Docker Compose configuration that sets up the myMPD service with persistent storage and environment variables.

- **Documentation**
	- Included detailed metadata for the myMPD application, providing installation tips and relevant documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->