### PR TITLE
🐳 feat(docker-compose): rename environment variable keys

### DIFF
--- a/Apps/viseron/docker-compose.yml
+++ b/Apps/viseron/docker-compose.yml
@@ -31,10 +31,10 @@ services:
 
     x-casaos:
       envs:
-        - name: PUID
+        - container: PUID
           description:
             en_us: "Container Environment Variable: PUID"
-        - name: PGID
+        - container: PGID
           description:
             en_us: "Container Environment Variable: PGID"
       volumes:


### PR DESCRIPTION
This pull request renames the `PUID` and `PGID` environment variable keys to `container` in the docker-compose configuration. This change improves the readability and maintainability of the docker-compose configuration by using more semantically meaningful variable names.