### PR TITLE
✨ feat(bookstack): Update MariaDB data volume mount path

### DIFF
--- a/Apps/bookstack/docker-compose.yml
+++ b/Apps/bookstack/docker-compose.yml
@@ -21,7 +21,9 @@ services:
       - /DATA/AppData/$AppID/config:/config
 
     # Environment variables
+    # docker run -it --rm --entrypoint /bin/bash lscr.io/linuxserver/bookstack:latest appkey
     environment:
+      - APP_KEY=base64:3w/hRS2HYVFH5tJqD9AFlyurTh8mBByMKeMRyH9kEEQ=
       - APP_URL=http://[change to your IP]:8080
       - DB_HOST=big-bear-bookstack-db
       - DB_USERNAME=bigbear
@@ -59,16 +61,16 @@ services:
       - MYSQL_USER=bigbear # Database user
       - MYSQL_PASSWORD=a3e8949f-484c-4877-afdb-391f892f9bb6 # Database password
     volumes:
-      - /DATA/AppData/$AppID/mysql:/var/lib/mysql # Mount the volume for MariaDB data
+      - /DATA/AppData/$AppID/mysql:/config # Mount the volume for MariaDB data
     restart: unless-stopped # Restart policy
     networks:
       - big_bear_bookstack_network # Connect to the bookstack-network
 
     x-casaos: # CasaOS specific configuration
       volumes:
-        - container: /var/lib/mysql
+        - container: /config
           description:
-            en_us: "Container Path: /var/lib/mysql"
+            en_us: "Container Path: /config"
       ports:
         - container: "3306"
           description:

--- a/Apps/bookstack/docker-compose.yml
+++ b/Apps/bookstack/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - /DATA/AppData/$AppID/config:/config
 
     # Environment variables
-    # docker run -it --rm --entrypoint /bin/bash lscr.io/linuxserver/bookstack:latest appkey
     environment:
       - APP_KEY=base64:3w/hRS2HYVFH5tJqD9AFlyurTh8mBByMKeMRyH9kEEQ=
       - APP_URL=http://[change to your IP]:8080
@@ -110,3 +109,8 @@ x-casaos:
   category: BigBearCasaOS
   # Port mapping information
   port_map: "8080"
+  # Tips
+  tips:
+    before_install:
+      en_us: |
+        Before you install read this: https://community.bigbeartechworld.com/t/added-bookstack-to-bigbearcasaos/1262#p-2263-documentation-3


### PR DESCRIPTION
This pull request introduces the following changes:

1. Updates the MariaDB data volume mount path from `/var/lib/mysql` to `/config` in the BookStack Docker Compose configuration. This change aligns the volume mount path with the recommended best practices for container-based applications, where the `/config` directory is typically used to store persistent application data.

2. Adds a new environment variable `APP_KEY` to the BookStack service, which is required for the application to function correctly. This environment variable is set to a base64-encoded value, which should be replaced with a unique value for the specific deployment.

These changes will improve the overall configuration and deployment of the BookStack application.