### PR TITLE
🔧 fix(docker-compose): update healthcheck retries

### DIFF
--- a/Apps/coolify/docker-compose.yml
+++ b/Apps/coolify/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     healthcheck:
       test: curl --fail http://127.0.0.1:80/api/health || exit 1
       interval: 5s
-      retries: "10"
+      retries: 10
       timeout: 2s
 
     depends_on:
@@ -308,7 +308,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U coolify", "-d", "coolify"]
       interval: 5s
-      retries: "10"
+      retries: 10
       timeout: 2s
 
     networks:
@@ -353,7 +353,7 @@ services:
     healthcheck:
       test: redis-cli ping
       interval: 5s
-      retries: "10"
+      retries: 10
       timeout: 2s
 
     networks:
@@ -383,7 +383,7 @@ services:
     healthcheck:
       test: wget -qO- http://127.0.0.1:6001/ready || exit 1
       interval: 5s
-      retries: "10"
+      retries: 10
       timeout: 2s
 
     networks:


### PR DESCRIPTION
Updates the healthcheck retries from string to integer for various services
in the docker-compose file. This ensures that the healthcheck retries are
properly parsed and handled by the Docker Compose engine.