### PR TITLE
✨ feat(phpmyadmin): Update service name in docker-compose

### DIFF
--- a/Apps/phpmyadmin/docker-compose.yml
+++ b/Apps/phpmyadmin/docker-compose.yml
@@ -57,7 +57,7 @@ x-casaos:
     - amd64
     - arm64
   # Main service of the application
-  main: app
+  main: phpmyadmin
   description:
     # Description in English
     en_us: phpMyAdmin - A web interface for MySQL and MariaDB.


### PR DESCRIPTION
## Description

This pull request updates the service name for the phpMyAdmin application in the `docker-compose.yml` file from `'app'` to `'phpmyadmin'`. This change better reflects the purpose of the service and makes it clearer which service is running the phpMyAdmin application.

## Changes

- Updated the service name in the `docker-compose.yml` file from `'app'` to `'phpmyadmin'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the main service reference in the application configuration to clarify the use of phpMyAdmin.
- **Bug Fixes**
	- Ensured accurate service identification in the CasaOS configuration for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->