### PR TITLE
✨ feat(phpmyadmin): update phpmyadmin docker image to 5.2.1

### DIFF
--- a/Apps/phpmyadmin/docker-compose.yml
+++ b/Apps/phpmyadmin/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # Service name: phpmyadmin
   phpmyadmin:
     # Docker image to be used for this service
-    image: phpmyadmin/phpmyadmin:5.2.1-fpm-alpine
+    image: phpmyadmin/phpmyadmin:5.2.1
 
     # Name of the container once it's up and running
     container_name: big-bear-phpmyadmin


### PR DESCRIPTION
The changes update the phpmyadmin docker image from the fpm-alpine
variant to the standard variant. This is done to simplify the
configuration and reduce the complexity of the deployment.