### PR TITLE
🔖 docs(playit-docker-web): update installation instructions

### DIFF
--- a/Apps/playit-docker-web/docker-compose.yml
+++ b/Apps/playit-docker-web/docker-compose.yml
@@ -75,4 +75,4 @@ x-casaos:
   tips:
     before_install:
       en_us: |
-        Read this before installing: https://community.bigbeartechworld.com/t/added-cloudflared-web-to-bigbearcasaos/2275?u=dragonfire1119
+        Read this before installing: https://community.bigbeartechworld.com/t/added-playit-docker-web-to-bigbearcasaos/2276?u=dragonfire1119


### PR DESCRIPTION
# Update Playit Docker Web installation instructions

## Changes
- Update the installation instructions for the Playit Docker Web application in the BigBearCasaOS community guide
- The new link points to the correct thread for the Playit Docker Web application

## Why
The current installation instructions were outdated and pointed to an incorrect thread. This update ensures the documentation provides the correct information for users setting up the Playit Docker Web application.