### PR TITLE
✨ feat(nextcloud-with-smbclient): Bump version to 0.0.4

### DIFF
--- a/Apps/nextcloud-with-smbclient/config.json
+++ b/Apps/nextcloud-with-smbclient/config.json
@@ -1,6 +1,6 @@
 {
   "id": "nextcloud-with-smbclient",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "image": "bigbeartechworld/big-bear-nextcloud-with-smbclient",
   "youtube": "",
   "docs_link": "",


### PR DESCRIPTION
This pull request bumps the version of the nextcloud-with-smbclient app from 0.0.3 to 0.0.4. This change reflects the latest improvements and updates made to the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version number of the nextcloud-with-smbclient application from 0.0.3 to 0.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->