### PR TITLE
✨ feat(docker-compose): update retries value to string

### DIFF
--- a/Apps/ayon/docker-compose.yml
+++ b/Apps/ayon/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:5000/api/info"]
       interval: 10s
       timeout: 2s
-      retries: 3
+      retries: "3"
 
     # Volumes to be mounted to the container
     volumes:


### PR DESCRIPTION
**Pull Request Description:**

This pull request updates the `retries` value in the `docker-compose.yml` file from an integer to a string. This change is necessary to ensure the value is properly parsed by the Docker Compose configuration.

The commit message for this change is:

<###>✨ feat(docker-compose): update retries value to string

Changes the retries value in the docker-compose.yml file from an
integer to a string. This is necessary to ensure the value is
properly parsed by the Docker Compose configuration.
<###>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated healthcheck configuration for services to use string format for retries, enhancing compatibility with the configuration parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->