### PR TITLE
🔖 feat(Romm): Upgrade Romm Docker image to 3.7.0-alpha.1

### DIFF
--- a/Apps/Romm/config.json
+++ b/Apps/Romm/config.json
@@ -1,6 +1,6 @@
 {
   "id": "Romm",
-  "version": "3.6.0",
+  "version": "3.7.0-alpha.1",
   "image": "zurdi15/romm",
   "youtube": "",
   "docs_link": "",

--- a/Apps/Romm/docker-compose.yml
+++ b/Apps/Romm/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # Service name: big-bear-romm
   # The `big-bear-romm` service definition
   big-bear-romm:
-    image: rommapp/romm:3.6.0 # Docker image for the application
+    image: rommapp/romm:3.7.0-alpha.1 # Docker image for the application
     container_name: big-bear-romm
     environment:
       - DB_HOST=big-bear-rommdb # Hostname of the MariaDB container


### PR DESCRIPTION
Upgrades the Romm Docker image from 3.6.0 to 3.7.0-alpha.1 in the
docker-compose.yml file. This update includes new features and
improvements that are necessary for the upcoming release.

This change was suggested here: https://community.bigbeartechworld.com/t/need-to-update-romm-to-alpha-rommapp-romm-3-7-0-alpha-1/2369?u=dragonfire1119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded the application to version 3.7.0-alpha.1, which may include enhancements and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->