### PR TITLE
🔨 fix(seafile): downgrade seafile version to 11.0.6

### DIFF
--- a/Apps/seafile/config.json
+++ b/Apps/seafile/config.json
@@ -1,6 +1,6 @@
 {
   "id": "seafile",
-  "version": "12.0.6",
+  "version": "11.0.6",
   "image": "seafileltd/seafile-mc",
   "youtube": "",
   "docs_link": "",

--- a/Apps/seafile/docker-compose.yml
+++ b/Apps/seafile/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-seafile
 
     # Image to be used for the container
-    image: seafileltd/seafile-mc:12.0.6
+    image: seafileltd/seafile-mc:11.0.6
 
     # Container restart policy
     restart: unless-stopped


### PR DESCRIPTION
**PR Description:**

This pull request addresses a compatibility issue with a third-party component by downgrading the Seafile version from 12.0.6 to 11.0.6. The changes have been made in the `config.json` and `docker-compose.yml` files.

The commit message provides the following details:

- Downgrade the Seafile version from 12.0.6 to 11.0.6
- This is necessary to address a compatibility issue with a third-party component that is not yet compatible with the latest Seafile version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Downgraded Seafile application version from 12.0.6 to 11.0.6
	- Updated Docker Compose configuration to use the corresponding Seafile image version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->