### PR TITLE
🔒 feat(wg-easy): update password hash

### DIFF
--- a/Apps/wg-easy/docker-compose.yml
+++ b/Apps/wg-easy/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - 51820:51820/udp
       - 51821:51821/tcp # UI port
 
-    x-casaos: # CasaOS specific configuration
+    # CasaOS specific configuration
+    x-casaos:
       volumes:
         - container: /etc/wireguard
           description:

--- a/Apps/wg-easy/docker-compose.yml
+++ b/Apps/wg-easy/docker-compose.yml
@@ -86,3 +86,8 @@ x-casaos:
   category: BigBearCasaOS
   # Port mapping information
   port_map: "51821"
+  # Installation instructions and documentation
+  tips:
+    before_install:
+      en_us: |
+        Read this before installing: https://community.bigbeartechworld.com/t/added-wg-easy-to-bigbearcasaos/1631#p-3101-documentation-3

--- a/Apps/wg-easy/docker-compose.yml
+++ b/Apps/wg-easy/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     # Environment variables for the container
     environment:
       WG_HOST: "[YOUR_PUBLIC_IP]"
-      PASSWORD_HASH: "$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW"
+      PASSWORD_HASH: '$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW'
       WG_DEFAULT_DNS: "1.1.1.1"
       WG_ALLOWED_IPS: 0.0.0.0/0, ::/0
 

--- a/Apps/wg-easy/docker-compose.yml
+++ b/Apps/wg-easy/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     # Environment variables for the container
     environment:
       WG_HOST: "[YOUR_PUBLIC_IP]"
-      PASSWORD: "adc1e1b1-7360-4971-8195-b397d526dde0"
+      PASSWORD_HASH: "$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW"
       WG_DEFAULT_DNS: "1.1.1.1"
       WG_ALLOWED_IPS: 0.0.0.0/0, ::/0
 


### PR DESCRIPTION
## Description

This pull request updates the `PASSWORD` environment variable for the WireGuard Easy VPN server to use a hashed password instead of a plaintext password. This change improves the security of the VPN server by ensuring the password is stored securely.

## Changes

- Update the `PASSWORD` environment variable to use a hashed password instead of plaintext
- Improve the security of the WireGuard Easy VPN server by storing the password in a more secure manner

## Benefits

- Increased security for the WireGuard Easy VPN server by using a hashed password instead of plaintext
- Reduced risk of password exposure or compromise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvement**
	- Enhanced password storage by implementing password hashing for the WireGuard Easy service.
	- Replaced plaintext password with a secure, hashed password representation.
- **Documentation**
	- Added a new tips section with installation instructions and documentation for CasaOS configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->