### PR TITLE
✨ feat(jlesage-firefox): add Firefox browser container

### DIFF
--- a/Apps/jlesage-firefox/config.json
+++ b/Apps/jlesage-firefox/config.json
@@ -1,0 +1,8 @@
+{
+  "id": "jlesage-firefox",
+  "version": "v24.12.1",
+  "image": "jlesage/firefox",
+  "youtube": "",
+  "docs_link": "",
+  "big_bear_cosmos_youtube": ""
+}

--- a/Apps/jlesage-firefox/docker-compose.yml
+++ b/Apps/jlesage-firefox/docker-compose.yml
@@ -1,0 +1,55 @@
+name: big-bear-jlesage-firefox # Name of the CasaOS application
+
+services:
+  big-bear-jlesage-firefox:
+    container_name: big-bear-jlesage-firefox # Name of the Docker container
+    image: jlesage/firefox:v24.12.1 # Docker image for the Firefox browser
+    ports:
+      - "5800:5800" # Expose port 5800 for VNC access
+    environment:
+      - VNC_PASSWORD=casaos # Set the VNC password to 'casaos'
+      - FF_OPEN_URL=https://community.bigbeartechworld.com/ # Set the default URL to Big Bear Tech World
+    volumes:
+      - /DATA/AppData/$AppID/config:/config:rw # Mount the host directory to the container's Downloads directory
+
+    x-casaos: # CasaOS specific configuration for the brave service
+      envs:
+        - container: VNC_PASSWORD
+          description:
+            en_us: VNC Password # Description for the VNC password environment variable
+        - container: FF_OPEN_URL
+          description:
+            en_us: Launch URL # Description for the launch URL environment variable
+      ports:
+        - container: "5800"
+          description:
+            en_us: "Container Port: 5800"
+      volumes:
+        - container: /config
+          description:
+            en_us: "Container Path: /config"
+            
+# Global CasaOS specific configuration
+x-casaos:
+  architectures: # Supported CPU architectures for the application
+    - amd64
+    - arm64
+  main: big-bear-jlesage-firefox # Specifies the main service of the application
+  description:
+    en_us: The GUI of the application is accessed through a modern web browser (no installation or configuration needed on the client side) or via any VNC client. # Description in English
+  tagline:
+    en_us: This project implements a Docker container for Firefox. # Short description or tagline in English
+  developer: "jlesage" # Developer's name or identifier (currently empty)
+  author: BigBearTechWorld # Author of this Docker Compose configuration
+  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/firefox.png # Icon URL for the application
+  thumbnail: "" # Thumbnail image URL
+  title:
+    en_us: Jlesage Firefox # Title in English
+  category: BigBearCasaOS # Category of the application
+  port_map: "5800" # Port mapping information for the service
+  scheme: http # Scheme for the service
+  # Installation instructions and documentation
+  tips:
+    before_install:
+      en_us: |
+        Read this before installing: https://community.bigbeartechworld.com/t/added-jlesage-firefox-to-bigbearcasaos/2506#p-4575-documentation-3


### PR DESCRIPTION
This pull request adds a new CasaOS application for the Jlesage Firefox browser container. The changes include:

- Added a `docker-compose.yml` file to define the Firefox container service
- Configured the container with a VNC password and a default launch URL
- Provided CasaOS-specific metadata, including supported architectures, description, and installation tips
- Added a `config.json` file with basic application information

The goal of these changes is to provide a convenient way for CasaOS users to access the Firefox browser through a web-based interface, without the need for local installation or configuration.