### PR TITLE
✨ refactor(pterodactyl-wings): simplify mount paths

### DIFF
--- a/Apps/pterodactyl-wings/docker-compose.yml
+++ b/Apps/pterodactyl-wings/docker-compose.yml
@@ -48,25 +48,13 @@ services:
       - "/etc/ssl/certs:/etc/ssl/certs:ro"
 
       # Mount a temporary directory for Pterodactyl
-      - "/DATA/AppData/$AppID/tmp:/tmp/pterodactyl/"
-
-      # Mount a temporary directory for Pterodactyl
       - "/tmp/pterodactyl:/tmp/pterodactyl/"
-
-      # Mount the configuration directory for Pterodactyl
-      - "/DATA/AppData/$AppID/etc:/etc/pterodactyl/"
 
       # Mount the configuration directory for Pterodactyl
       - "/etc/pterodactyl:/etc/pterodactyl/"
 
       # Mount the logs directory for Pterodactyl
-      - "/DATA/AppData/$AppID/logs:/var/log/pterodactyl/"
-
-      # Mount the logs directory for Pterodactyl
       - "/var/log/pterodactyl:/var/log/pterodactyl/"
-
-      # Mount the library directory for Pterodactyl
-      - "/DATA/AppData/$AppID/lib:/var/lib/pterodactyl/"
 
       # Mount the library directory for Pterodactyl
       - "/var/lib/pterodactyl:/var/lib/pterodactyl/"
@@ -85,7 +73,6 @@ services:
         - container: WINGS_USERNAME
           description:
             en_us: Username for the Wings process
-
       ports:
         - container: "8080"
           description:
@@ -148,7 +135,7 @@ x-casaos:
         Copy the Configuration: After creating the node, the panel will provide a configuration file. You need to copy the content of this configuration and place it in:
 
         ```
-        /DATA/AppData/big-bear-pterodactyl-wings/etc/config.yml
+        /etc/pterodactyl/config.yml
         ```
 
         Tip: Use the CasaOS files app for an easy file management experience.


### PR DESCRIPTION
Simplify the mount paths for the Pterodactyl Wings container by removing the `$AppID` variable and using more generic paths. This makes the configuration more portable and easier to manage.

The key changes are:

- Simplify the mount paths for tmp, etc, logs, and lib directories
- Remove the `$AppID` variable from the mount paths
- Use more generic paths like `/etc/pterodactyl` and `/var/log/pterodactyl`

This change makes the configuration more flexible and easier to maintain, as the paths no longer depend on a specific application ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Updated Docker volume mounts for Pterodactyl Wings application
	- Simplified configuration file paths
	- Redirected temporary, configuration, log, and library directories to standard container paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->