### PR TITLE
🔧 feat(docker-compose): Update lyrionmusicserver icon URL

### DIFF
--- a/Apps/lyrionmusicserver/docker-compose.yml
+++ b/Apps/lyrionmusicserver/docker-compose.yml
@@ -106,7 +106,7 @@ x-casaos:
   # Author of this configuration (docker-compose.yml)
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-lyrionmusicserver/Apps/lyrionmusicserver/logo.png
+  icon: https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-casaos/Apps/lyrionmusicserver/logo.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:


### PR DESCRIPTION
## Description
This pull request updates the icon URL for the `lyrionmusicserver` application in the `docker-compose.yml` file. The new URL points to the `logo.png` file in the `big-bear-casaos` repository instead of the previous location.

## Changes
<###>🔧 feat(docker-compose): Update lyrionmusicserver icon URL

Updates the icon URL for the lyrionmusicserver application in the
docker-compose.yml file. The new URL points to the logo.png file in the
big-bear-casaos repository instead of the previous location.
<###>

## Motivation
The previous icon URL was outdated, and this change ensures that the correct logo is displayed for the `lyrionmusicserver` application.