### PR TITLE
chore(deps): update adguard/adguardhome docker tag to v0.107.56

### DIFF
--- a/Apps/adguard-home/docker-compose.yml
+++ b/Apps/adguard-home/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: adguard-home
     # Docker image to be used
-    image: adguard/adguardhome:v0.107.55
+    image: adguard/adguardhome:v0.107.56
     # Resources for the service
     deploy:
       resources:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated AdGuard Home Docker image to version v0.107.56, potentially including bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->