### PR TITLE
🔧 feat(nextcloud): Update restart policy for Redis and Cron

### DIFF
--- a/Apps/nextcloud/docker-compose.yml
+++ b/Apps/nextcloud/docker-compose.yml
@@ -128,7 +128,7 @@ services:
     container_name: redis-nextcloud
     user: "1000:1000"
     image: redis:6.2.6
-    restart: on-failure
+    restart: unless-stopped
     volumes:
       - "/DATA/AppData/$AppID/redis:/data" # Mount the Redis data directory
     networks:
@@ -153,7 +153,7 @@ services:
 
   cron:
     image: bigbeartechworld/big-bear-nextcloud-with-smbclient:0.0.4
-    restart: on-failure
+    restart: unless-stopped
     volumes:
       - /DATA/AppData/$AppID/html:/var/www/html
     entrypoint: /cron.sh


### PR DESCRIPTION
This pull request updates the restart policy for the Redis and Cron services in the Nextcloud Docker Compose configuration. The previous policy of "on-failure" has been changed to "unless-stopped", which will ensure that the containers are automatically restarted unless they are explicitly stopped.

This change is intended to improve the reliability and availability of the Nextcloud application, as it will help ensure that the Redis and Cron services are always running, even in the event of a temporary failure or system restart.