### PR TITLE
🔧 refactor(ollama): use common icon for all variants

### DIFF
--- a/Apps/ollama-amd/docker-compose.yml
+++ b/Apps/ollama-amd/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama-amd.png
+  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ollama-cpu/docker-compose.yml
+++ b/Apps/ollama-cpu/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama-cpu.png
+  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ollama-nvidia/docker-compose.yml
+++ b/Apps/ollama-nvidia/docker-compose.yml
@@ -69,7 +69,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama-nvidia.png
+  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:


### PR DESCRIPTION
**Refactor Ollama icon URLs to use a common icon**

The changes in this pull request update the icon URLs for the Ollama application in the `docker-compose.yml` files for the AMD, NVIDIA, and CPU variants. The common icon URL is used instead of the variant-specific icons to simplify the configuration and maintain a consistent appearance across all Ollama deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the application icons to a unified, streamlined design across multiple deployments, ensuring a consistent visual experience for end-users. All functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->