### PR TITLE
🔖 feat(pihole-unbound): Update container image version

### DIFF
--- a/Apps/pihole-unbound/config.json
+++ b/Apps/pihole-unbound/config.json
@@ -1,6 +1,6 @@
 {
   "id": "pihole-unbound",
-  "version": "2024.07.0",
+  "version": "2025.02.1",
   "image": "bigbeartechworld/big-bear-pihole-unbound",
   "youtube": "https://youtu.be/ByFSgnnUuBI",
   "docs_link": "https://community.bigbeartechworld.com/t/added-pihole-and-unbound-to-bigbearcasaos/191",

--- a/Apps/pihole-unbound/docker-compose.yml
+++ b/Apps/pihole-unbound/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-pihole-unbound
 
     # Image to be used for the container
-    image: bigbeartechworld/big-bear-pihole-unbound:2024.07.0
+    image: bigbeartechworld/big-bear-pihole-unbound:2025.02.1
 
     # Container restart policy
     restart: unless-stopped


### PR DESCRIPTION
# Update pihole-unbound container image version

## Description

This pull request updates the container image version for the `pihole-unbound` service from `2024.07.0` to `2025.02.1`. This change is necessary to ensure the latest version of the `pihole-unbound` container is used, which may include bug fixes, security updates, or new features.

The changes have been made in both the `docker-compose.yml` and `config.json` files.

## Changes

<###>🔖 feat(pihole-unbound): Update container image version

Updates the container image version from 2024.07.0 to 2025.02.1 in both the
docker-compose.yml and config.json files. This change is necessary to
ensure the latest version of the pihole-unbound container is used, which
may include bug fixes, security updates, or new features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application configuration version to 2025.02.1.
  - Refreshed the service's container image to version 2025.02.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->