### PR TITLE
✨ feat(owncloud): update database and redis configurations

### DIFF
--- a/Apps/owncloud/docker-compose.yml
+++ b/Apps/owncloud/docker-compose.yml
@@ -53,6 +53,10 @@ services:
       timeout: 10s
       retries: 5
 
+    depends_on:
+      - big-bear-owncloud-db
+      - big-bear-owncloud-redis
+
     x-casaos: # CasaOS specific configuration
       envs:
         - container: OWNCLOUD_DOMAIN
@@ -102,13 +106,14 @@ services:
 
   big-bear-owncloud-db:
     container_name: big-bear-owncloud-db
-    image: mariadb:10.6 # minimum required ownCloud version is 10.9
+    image: mariadb:10.6
     restart: unless-stopped
     environment:
       - MYSQL_ROOT_PASSWORD=f01914eb-2be3-4164-a57c-08e6518f313a
       - MYSQL_USER=bigbear
       - MYSQL_PASSWORD=f01914eb-2be3-4164-a57c-08e6518f313a
       - MYSQL_DATABASE=big_bear_owncloud
+      - MARIADB_AUTO_UPGRADE=1
     command: ["--max-allowed-packet=128M", "--innodb-log-file-size=64M"]
     healthcheck:
       test:
@@ -117,14 +122,14 @@ services:
           "mysqladmin",
           "ping",
           "-u",
-          "root",
+          "bigbear",
           "--password=f01914eb-2be3-4164-a57c-08e6518f313a",
         ]
       interval: 10s
       timeout: 5s
       retries: 5
     volumes:
-      - /DATA/AppData/$AppID/data/mysql:/var/lib/mysql
+      - /DATA/AppData/$AppID/mysql:/var/lib/mysql
     networks:
       - big_bear_owncloud_network
 
@@ -162,7 +167,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - /DATA/AppData/$AppID/data/redis:/data
+      - /DATA/AppData/$AppID/redis:/data
     networks:
       - big_bear_owncloud_network
 
@@ -178,6 +183,7 @@ services:
 
 networks:
   big_bear_owncloud_network:
+    name: big_bear_owncloud_network
     driver: bridge
 
 # CasaOS specific configuration


### PR DESCRIPTION
This pull request introduces several updates to the ownCloud application's database and Redis configurations:

- Update the MySQL user from `root` to `bigbear`
- Change the MySQL data volume path from `/DATA/AppData/$AppID/data/mysql` to `/DATA/AppData/$AppID/mysql`
- Add the `MARIADB_AUTO_UPGRADE=1` environment variable to the database container
- Update the Redis data volume path from `/DATA/AppData/$AppID/data/redis` to `/DATA/AppData/$AppID/redis`
- Add `depends_on` for the database and Redis containers to the ownCloud container
- Add a name to the `big_bear_owncloud_network` network

These changes aim to improve the overall configuration and setup of the ownCloud application, ensuring better compatibility and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved service startup by ensuring that required components wait for dependencies to be ready.
  - Enabled automatic database upgrades with an enhanced health check that uses a dedicated user.
  - Streamlined storage configurations for database and cache services.
  - Standardized network settings for more consistent connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->