### PR TITLE
✨ feat(obsidian-livesync): add YouTube video link

### DIFF
--- a/Apps/obsidian-livesync/config.json
+++ b/Apps/obsidian-livesync/config.json
@@ -2,7 +2,7 @@
   "id": "obsidian-livesync",
   "version": "3.4.3",
   "image": "couchdb",
-  "youtube": "",
+  "youtube": "https://youtu.be/-n1abMPLmFg",
   "docs_link": "",
   "big_bear_cosmos_youtube": ""
 }


### PR DESCRIPTION
# Add YouTube Video Link to obsidian-livesync

## Description

This pull request adds a YouTube video link to the `config.json` file for the `obsidian-livesync` app. The video link provides users with a helpful tutorial or overview to better understand the functionality of the app.

## Changes

<###>✨ feat(obsidian-livesync): add YouTube video link

Adds a YouTube video link to the `config.json` file for the `obsidian-livesync` app. This provides users with a helpful tutorial or overview video to better understand the functionality of the app.

## Benefits

- Provides users with a visual guide to using the `obsidian-livesync` app
- Helps new users quickly understand the app's features and capabilities
- Improves the overall user experience and onboarding process for the app