### PR TITLE
Fixed Frontend Port for Penpot 

### DIFF
--- a/Apps/penpot/docker-compose.yml
+++ b/Apps/penpot/docker-compose.yml
@@ -24,8 +24,8 @@ services:
 
     # Ports mapping between host and container
     ports:
-      # Mapping port 9001 of the host to port 80 of the container
-      - "9001:80"
+      # Mapping port 9001 of the host to port 8080 of the container
+      - "9001:8080"
 
     # Other services that this service depends on
     depends_on:
@@ -42,9 +42,9 @@ services:
           description:
             en_us: "Local Assets directory"
       ports:
-        - container: "80"
+        - container: "8080"
           description:
-            en_us: "Container Port: 80"
+            en_us: "Container Port: 8080"
 
   # Definition for penpot-backend service
   penpot-backend:


### PR DESCRIPTION
This pull request includes changes to the `Apps/penpot/docker-compose.yml` file to update the port mappings for the `penpot` service. The changes ensure that the container uses port 8080 instead of port 80.

Port mapping updates:

* Updated the host-to-container port mapping from `9001:80` to `9001:8080`.
* Updated the container port from `80` to `8080` and updated the corresponding description to reflect this change.

[Reference](https://github.com/penpot/penpot/blob/dd30e939aedd90cda36177a0ea9a0c5d22cf1ba9/docker/images/docker-compose.yaml#L78)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the front-end service’s network configuration to use a new container port, ensuring that the host remains mapped to port 9001 while the internal service now runs on port 8080 with updated metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->