### PR TITLE
🔧 [pihole-unbound] Update environment variables in Dockerfile for Pi-hole v6 compatibility

### DIFF
--- a/Apps/pihole-unbound/docker-compose.yml
+++ b/Apps/pihole-unbound/docker-compose.yml
@@ -20,9 +20,8 @@ services:
     # Environment variables
     environment:
       TZ: "America/Chicago"
-      WEBPASSWORD: "your_password"
-      DNS1: "127.0.0.1#5353" # Use Unbound
-      DNS2: "no" # No secondary DNS
+      FTLCONF_webserver_api_password: "your_password"
+      FTLCONF_dns_upstreams: "127.0.0.1#5353" # Use Unbound IPs delimited by ; ex: 8.8.8.8;8.8.4.4
 
     # Volumes to be mounted to the container
     volumes:


### PR DESCRIPTION
Updated environment variable format to match Pi-hole v6 standards:
- Changed password configuration to use 'FTLCONF_webserver_api_password'
- Updated DNS upstreams configuration to 'FTLCONF_dns_upstreams'

These changes ensure that the Docker setup remains functional and compatible with the latest Pi-hole release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced DNS configuration now supports specifying multiple upstream servers using a flexible new format.

- **Chores**
  - Updated configuration settings with improved naming conventions, replacing legacy password and DNS parameters for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->