### PR TITLE
🔧 [pihole] Update environment variables in Dockerfile for Pi-hole v6 compatibility

### DIFF
--- a/Apps/pihole/docker-compose.yml
+++ b/Apps/pihole/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     # Environment variables
     environment:
       TZ: "UTC"
-      WEBPASSWORD: "your_password"
+      FTLCONF_webserver_api_password: "your_password"
 
     # Volumes to be mounted to the container
     volumes:


### PR DESCRIPTION
Updated environment variable format to match Pi-hole v6 standards:
- Changed password configuration to use 'FTLCONF_webserver_api_password'

These changes ensure that the Docker setup remains functional and compatible with the latest Pi-hole release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application's environment configuration for managing web access credentials to better align with current practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->