### PR TITLE
🐳 feat(docker-compose): update tmp volume mount path

### DIFF
--- a/Apps/morphos/docker-compose.yml
+++ b/Apps/morphos/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     # These mounts allow the container to interact with the host system
     volumes:
       # Temporary storage for morphos
-      - /DATA/AppData/morphos/tmp:/tmp
+      - /DATA/AppData/$AppID/tmp:/tmp
 
     # Map port 8080 on the host to port 8080 on the container
     ports:


### PR DESCRIPTION
This pull request updates the temporary storage volume mount path for the morphos container in the Docker Compose configuration. The changes include:

- Using a dynamic `$AppID` variable instead of a hardcoded path for the temporary storage volume mount.
- This allows for better organization and separation of data for different applications.

The changes are described in the commit message:

> 🐳 feat(docker-compose): update tmp volume mount path
>
> Updates the temporary storage volume mount path for the
> morphos container to use a dynamic $AppID variable instead
> of a hardcoded path. This allows for better organization and
> separation of data for different applications.