### PR TITLE
🔖 feat(user-management): Bump version to 0.1.0

### DIFF
--- a/Apps/big-bear-casaos-user-management/config.json
+++ b/Apps/big-bear-casaos-user-management/config.json
@@ -1,6 +1,6 @@
 {
   "id": "big-bear-casaos-user-management",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "image": "bigbeartechworld/big-bear-casaos-user-management",
   "youtube": "https://youtu.be/-a9k8fLAbRE",
   "docs_link": "",

--- a/Apps/big-bear-casaos-user-management/docker-compose.yml
+++ b/Apps/big-bear-casaos-user-management/docker-compose.yml
@@ -1,6 +1,6 @@
 # Docker Compose configuration for BigBearCasaOS User Management Service
 # This service provides a web interface for managing CasaOS users and permissions
-# Version: 0.0.1
+# Version: 0.1.0
 
 # Name of the big-bear-casaos-user-management application
 name: big-bear-casaos-user-management
@@ -14,7 +14,7 @@ services:
     container_name: big-bear-casaos-user-management
 
     # Image to be used for the container specifies the btop version and source
-    image: bigbeartechworld/big-bear-casaos-user-management:0.0.1
+    image: bigbeartechworld/big-bear-casaos-user-management:0.1.0
 
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped


### PR DESCRIPTION
# Bump version to 0.1.0 for user-management

## Description
This pull request bumps the version of the `big-bear-casaos-user-management` app from `0.0.1` to `0.1.0`. The update includes bug fixes and improvements to the user management functionality.

## Changes
- Bumped the version to `0.1.0` in the codebase