### PR TITLE
✨ feat(viseron): Upgrade to version 3.0.0 and update container paths

### DIFF
--- a/Apps/viseron/config.json
+++ b/Apps/viseron/config.json
@@ -1,6 +1,6 @@
 {
   "id": "viseron",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "image": "roflcoopter/viseron",
   "youtube": "",
   "docs_link": "",

--- a/Apps/viseron/docker-compose.yml
+++ b/Apps/viseron/docker-compose.yml
@@ -12,22 +12,32 @@ services:
     container_name: big-bear-viseron
 
     # Image to be used for the container
-    image: roflcoopter/viseron:2.3.1
+    image: roflcoopter/viseron:3.0.0
 
     # Container restart policy
     restart: unless-stopped
 
+    # Shared memory size
+    shm_size: "1024mb"
+
     # Volumes to be mounted to the container
     volumes:
-      - /DATA/AppData/$AppID/recordings:/recordings
+      - /DATA/AppData/$AppID/segments:/segments
+      - /DATA/AppData/$AppID/snapshots:/snapshots
+      - /DATA/AppData/$AppID/thumbnails:/thumbnails
+      - /DATA/AppData/$AppID/event_clips:/event_clips
       - /DATA/AppData/$AppID/config:/config
       - /etc/localtime:/etc/localtime:ro
-      - /var/run/docker.sock:/var/run/docker.sock
 
     # Ports mapping between host and container
     ports:
       # Mapping port 8888 of the host to port 8888 of the container
       - "8888:8888"
+
+    # Environment variables
+    environment:
+      - PUID=1000
+      - PGID=1000
 
     x-casaos:
       envs:
@@ -38,18 +48,24 @@ services:
           description:
             en_us: "Container Environment Variable: PGID"
       volumes:
-        - container: /recordings
+        - container: /segments
           description:
-            en_us: "Container Path: /recordings"
+            en_us: "Container Path: /segments"
+        - container: /snapshots
+          description:
+            en_us: "Container Path: /snapshots"
+        - container: /thumbnails
+          description:
+            en_us: "Container Path: /thumbnails"
+        - container: /event_clips
+          description:
+            en_us: "Container Path: /event_clips"
         - container: /config
           description:
             en_us: "Container Path: /config"
         - container: /etc/localtime
           description:
             en_us: "Container Path: /etc/localtime"
-        - container: /var/run/docker.sock
-          description:
-            en_us: "Container Path: /var/run/docker.sock"
       ports:
         - container: "8888"
           description:


### PR DESCRIPTION
This pull request upgrades the Viseron container to version 3.0.0 and updates the container paths to better align with the new version's structure. The key changes are:

- Upgrade the container image to `roflcoopter/viseron:3.0.0`
- Change the container path for recordings to `/segments`, `/snapshots`, `/thumbnails`, and `/event_clips`
- Remove the mapping for `/var/run/docker.sock` as it is no longer required
- Add `shm_size` configuration to increase the shared memory size
- Update the environment variables to include `PUID` and `PGID`