### PR TITLE
🔖 feat(joplin): Upgrade Joplin server to version 3.3.13

### DIFF
--- a/Apps/joplin/config.json
+++ b/Apps/joplin/config.json
@@ -1,7 +1,7 @@
 {
   "id": "joplin",
-  "version": "3.0.1",
-  "image": "florider89/joplin-server",
+  "version": "3.3.13",
+  "image": "joplin/server:3.3.13",
   "youtube": "https://youtu.be/FjVyg0X-_zc",
   "docs_link": "",
   "big_bear_cosmos_youtube": ""

--- a/Apps/joplin/docker-compose.yml
+++ b/Apps/joplin/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # Configuration for the Joplin server service
   big-bear-joplin:
     container_name: big-bear-joplin # The name of the Docker container for easy reference.
-    image: florider89/joplin-server:3.0.1 # Docker image to use, specifying version.
+    image: joplin/server:3.3.13 # Docker image to use, specifying version.
     restart: unless-stopped # Policy to automatically restart the container unless manually stopped.
 
     # Environment variables for the Joplin server, configuring database connection and application settings.


### PR DESCRIPTION
- Upgrade Joplin server to version 3.3.13
- Provides the latest features and bug fixes for the Joplin note-taking application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Joplin app to use the latest server version (3.3.13) and switched to the official Docker image for improved reliability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->