### PR TITLE
🔧 refactor: Update developer information in app metadata

### DIFF
--- a/Apps/poste-io/docker-compose.yml
+++ b/Apps/poste-io/docker-compose.yml
@@ -60,7 +60,7 @@ x-casaos:
     en_us: Full stack mail server solution with SSL TLS support. POP3s, SMTP(s), IMAPs, RSPAMD, Clamav, Roundcube(HTTPS), SPF, DKIM with easy installation and web administration.
   tagline:
     en_us: Free version of full mail server solution. POP3, SMTP, IMAP, Spamassassin, WebMail, WebAdmin
-  developer: "bigbeartechworld"
+  developer: "analogic"
   author: BigBearTechWorld
   icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/poste.png"
   thumbnail: "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-casaos/Apps/poste-io/thumbnail.png"

--- a/Apps/stalwart-mail/docker-compose.yml
+++ b/Apps/stalwart-mail/docker-compose.yml
@@ -81,7 +81,7 @@ x-casaos:
     en_us: Stalwart Mail Server is an open-source mail server solution with JMAP, IMAP4, POP3, and SMTP support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.
   tagline:
     en_us: Secure & Modern All-in-One Mail Server (IMAP, JMAP, POP3, SMTP) 🛡️
-  developer: "bigbeartechworld"
+  developer: "stalwartlabs"
   author: BigBearTechWorld
   icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/png/stalwart-mail-server.png"
   thumbnail: "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-casaos/Apps/big-bear-stalwart-mail/thumbnail.gif"


### PR DESCRIPTION
- Updated developer information in app metadata for "Stalwart Mail Server" and "Poste.io" apps
- "Stalwart Mail Server" app is now attributed to "stalwartlabs" instead of "bigbeartechworld"
- "Poste.io" app is now attributed to "analogic" instead of "bigbeartechworld"