### PR TITLE
🔥 feat: remove app from recommendation list

### DIFF
--- a/recommend-list.json
+++ b/recommend-list.json
@@ -1,5 +1,1 @@
-[
-    {
-        "appid": "big-bear-casaos-user-management"
-    }
-]
+[]


### PR DESCRIPTION
- Removed the `big-bear-casaos-user-management` app from the recommendation list as it is no longer needed or relevant.