### PR TITLE
Immich downgrade postgres image to 14

### DIFF
--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -64,7 +64,7 @@ services:
   # Configuration for Database service
   database:
     container_name: immich-postgres # Name of the running container
-    image: ghcr.io/immich-app/postgres:16-vectorchord0.3.0-pgvectors0.2.0 # Image to be used
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos
       POSTGRES_USER: casaos

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -118,7 +118,7 @@ services:
   # Configuration for Database service
   database:
     container_name: immich-postgres # Name of the running container
-    image: ghcr.io/immich-app/postgres:16-vectorchord0.3.0-pgvectors0.2.0 # Image to be used
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos
       POSTGRES_USER: casaos

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,10 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["ghcr.io/immich-app/postgres"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "rocket.chat",
         "ghcr.io/immich-app/immich-machine-learning",


### PR DESCRIPTION
- Downgraded the Postgres image used in the Immich application's Docker Compose configuration from version 16 to version 14 to address compatibility issues.
- Disabled Renovate updates for the `ghcr.io/immich-app/postgres` Docker image to prevent unintended updates to the Postgres version, which could potentially break the application.