### PR TITLE
✨ feat(obsidian-livesync): add video tutorial link to docker-compose

### DIFF
--- a/Apps/obsidian-livesync/docker-compose.yml
+++ b/Apps/obsidian-livesync/docker-compose.yml
@@ -83,4 +83,6 @@ x-casaos:
         bash -c "$(wget -qLO - https://raw.githubusercontent.com/bigbeartechworld/big-bear-scripts/master/generate-obsidian-livesync-local-ini/run.sh)"
         ```
 
+        Video Tutorial: https://youtu.be/-n1abMPLmFg
+
         After running this script, you need to restart the container.


### PR DESCRIPTION
- Adds a new line in the docker-compose.yml file to include a link to a video tutorial for the Obsidian LiveSync setup
- Provides users with an additional resource to help them configure the service