### PR TITLE
🔧 feat(portainer): update icon URLs

### DIFF
--- a/Apps/portainer-agent/docker-compose.yml
+++ b/Apps/portainer-agent/docker-compose.yml
@@ -39,7 +39,7 @@ x-casaos:
     en_us: Portainer Agent
   developer: "portainer" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/portainer-alt.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/portainer.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/portainer/docker-compose.yml
+++ b/Apps/portainer/docker-compose.yml
@@ -46,7 +46,7 @@ x-casaos:
     en_us: Portainer
   developer: "portainer" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/portainer-alt.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/portainer.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English


### PR DESCRIPTION
- Update icon URLs for Portainer and Portainer Agent applications in `docker-compose.yml` files
- New icon URLs point to a different source at `https://cdn.jsdelivr.net/gh/selfhst/icons/png/portainer.png`, which likely provides a more suitable or updated icon