### PR TITLE
🔧 feat(apps): update icons to use selfhst/icons

### DIFF
--- a/Apps/adguard-home-host/docker-compose.yml
+++ b/Apps/adguard-home-host/docker-compose.yml
@@ -66,7 +66,7 @@ x-casaos:
   # Author of this particular configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/adguard-home.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/adguard-home.png
   # Thumbnail image for the application (if any)
   thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/thumbnail.png
   # Title for the application

--- a/Apps/adguard-home/docker-compose.yml
+++ b/Apps/adguard-home/docker-compose.yml
@@ -79,7 +79,7 @@ x-casaos:
   # Author of this particular configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/adguard-home.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/adguard-home.png
   # Thumbnail image for the application (if any)
   thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/thumbnail.png
   # Title for the application

--- a/Apps/audiobookshelf/docker-compose.yml
+++ b/Apps/audiobookshelf/docker-compose.yml
@@ -67,7 +67,7 @@ x-casaos:
   # Author of this configuration
   author: advplyr
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/audiobookshelf.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/audiobookshelf.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/authentik/docker-compose.yml
+++ b/Apps/authentik/docker-compose.yml
@@ -176,7 +176,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/authentik.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/authentik.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/baserow/docker-compose.yml
+++ b/Apps/baserow/docker-compose.yml
@@ -54,7 +54,7 @@ x-casaos:
     en_us: Baserow # Short description or tagline in English
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/baserow.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/baserow.png # Icon for the application
   thumbnail: "https://github.com/bram2w/baserow/raw/master/docs/assets/screenshot.png" # Thumbnail image (currently empty)
   title:
     en_us: Baserow # Title in English

--- a/Apps/bookstack/docker-compose.yml
+++ b/Apps/bookstack/docker-compose.yml
@@ -99,7 +99,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/bookstack.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/bookstack.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/brave/docker-compose.yml
+++ b/Apps/brave/docker-compose.yml
@@ -35,7 +35,7 @@ x-casaos:
     en_us: Brave # Short description or tagline in English
   developer: "kasmweb" # Developer's name or identifier (currently empty)
   author: BigBearTechWorld # Author of this Docker Compose configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/brave.png # Icon URL for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/brave.png # Icon URL for the application
   thumbnail: "" # Thumbnail image URL
   title:
     en_us: Brave # Title in English

--- a/Apps/budibase/docker-compose.yml
+++ b/Apps/budibase/docker-compose.yml
@@ -55,7 +55,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/budibase.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/budibase.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/cadvisor/docker-compose.yml
+++ b/Apps/cadvisor/docker-compose.yml
@@ -75,7 +75,7 @@ x-casaos:
     en_us: cAdvisor # Short description or tagline in English
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/cadvisor.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/cadvisor.png # Icon for the application
   thumbnail: "" # Thumbnail image
   title:
     en_us: cAdvisor # Title in English

--- a/Apps/chrome/docker-compose.yml
+++ b/Apps/chrome/docker-compose.yml
@@ -35,7 +35,7 @@ x-casaos:
     en_us: chrome # Short description or tagline in English
   developer: "kasmweb" # Developer's name or identifier (currently empty)
   author: BigBearTechWorld # Author of this Docker Compose configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/chrome.png # Icon URL for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/google-chrome.png # Icon URL for the application
   thumbnail: "" # Thumbnail image URL
   title:
     en_us: chrome # Title in English

--- a/Apps/chromium/docker-compose.yml
+++ b/Apps/chromium/docker-compose.yml
@@ -35,7 +35,7 @@ x-casaos:
     en_us: chromium # Short description or tagline in English
   developer: "kasmweb" # Developer's name or identifier (currently empty)
   author: BigBearTechWorld # Author of this Docker Compose configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/chromium.png # Icon URL for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/chromium.png # Icon URL for the application
   thumbnail: "" # Thumbnail image URL
   title:
     en_us: chromium # Title in English

--- a/Apps/cloudflared-web/docker-compose.yml
+++ b/Apps/cloudflared-web/docker-compose.yml
@@ -75,7 +75,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/cloudflare.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/cloudflare.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/code-server/docker-compose.yml
+++ b/Apps/code-server/docker-compose.yml
@@ -54,7 +54,7 @@ x-casaos:
     en_us: Code Server # Short description or tagline in English
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/code-server.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/coder.png # Icon for the application
   thumbnail: "" # Thumbnail image (currently empty)
   title:
     en_us: Code Server # Title in English

--- a/Apps/crafty/docker-compose.yml
+++ b/Apps/crafty/docker-compose.yml
@@ -90,7 +90,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/crafty-controller.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/crafty-controller.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/cyberchef/docker-compose.yml
+++ b/Apps/cyberchef/docker-compose.yml
@@ -47,7 +47,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/cyberchef.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/cyberchef.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/dashdot/docker-compose.yml
+++ b/Apps/dashdot/docker-compose.yml
@@ -43,7 +43,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/dashdot.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/dashdot.png
   # Thumbnail image URL for the application (currently empty)
   thumbnail: ""
   # Title for the application

--- a/Apps/dashy/docker-compose.yml
+++ b/Apps/dashy/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/dashy.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/dashy.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/diun/docker-compose.yml
+++ b/Apps/diun/docker-compose.yml
@@ -80,7 +80,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/diun.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/diun.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/dockge/docker-compose.yml
+++ b/Apps/dockge/docker-compose.yml
@@ -67,7 +67,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/dockge.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/dockge.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/filebrowser/docker-compose.yml
+++ b/Apps/filebrowser/docker-compose.yml
@@ -100,7 +100,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/filebrowser.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/filebrowser-quantum.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/firefox/docker-compose.yml
+++ b/Apps/firefox/docker-compose.yml
@@ -35,7 +35,7 @@ x-casaos:
     en_us: Firefox # Short description or tagline in English
   developer: "kasmweb" # Developer's name or identifier (currently empty)
   author: BigBearTechWorld # Author of this Docker Compose configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/firefox.png # Icon URL for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/firefox.png # Icon URL for the application
   thumbnail: "" # Thumbnail image URL
   title:
     en_us: Firefox # Title in English

--- a/Apps/flame/docker-compose.yml
+++ b/Apps/flame/docker-compose.yml
@@ -82,7 +82,7 @@ x-casaos:
   author: BigBearCommunity
 
   # URL pointing to the icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/flame.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/flame.png
 
   # URL pointing to a thumbnail image representing the application
   thumbnail: https://github.com/pawelmalak/flame/raw/master/.github/home.png

--- a/Apps/flcontainers-guacamole/docker-compose.yml
+++ b/Apps/flcontainers-guacamole/docker-compose.yml
@@ -51,7 +51,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/guacamole.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/apache-guacamole.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/focalboard/docker-compose.yml
+++ b/Apps/focalboard/docker-compose.yml
@@ -50,7 +50,7 @@ x-casaos:
   # Author of this particular configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/focalboard.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/focalboard.png
   # Thumbnail image for the application (if any)
   thumbnail: ""
   # Title for the application

--- a/Apps/ghost/docker-compose.yml
+++ b/Apps/ghost/docker-compose.yml
@@ -131,7 +131,7 @@ x-casaos:
   # Author of this particular configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ghost.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ghost.png
   # Thumbnail image for the application (if any)
   thumbnail: ""
   # Title for the application

--- a/Apps/ghostfolio/docker-compose.yml
+++ b/Apps/ghostfolio/docker-compose.yml
@@ -164,7 +164,7 @@ x-casaos:
     en_us: Ghostfolio # Short description or tagline
   developer: "ghostfolio" # Developer name or identifier
   author: BigBearTechWorld # Configuration author
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ghostfolio.png # Application icon URL
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ghostfolio.png # Application icon URL
   thumbnail: "" # Thumbnail image URL (empty if not available)
   title:
     en_us: Ghostfolio # Application title in English

--- a/Apps/glances/docker-compose.yml
+++ b/Apps/glances/docker-compose.yml
@@ -60,7 +60,7 @@ x-casaos:
     en_us: Glances # Short description or tagline in English
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/glances.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/glances.png # Icon for the application
   thumbnail: "" # Thumbnail image (currently empty)
   title:
     en_us: Glances # Title in English

--- a/Apps/gluetun/docker-compose.yml
+++ b/Apps/gluetun/docker-compose.yml
@@ -77,7 +77,7 @@ x-casaos:
     en_us: Gluetun
   developer: "portainer" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/gluetun.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/gluetun.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/gotify/docker-compose.yml
+++ b/Apps/gotify/docker-compose.yml
@@ -43,7 +43,7 @@ x-casaos:
     en_us: Gotify # Short description or tagline in English
   developer: "gotify" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/gotify.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/gotify.png # Icon for the application
   thumbnail: "" # Thumbnail image (currently empty)
   title: # Title in different languages
     en_us: Gotify # Title in English

--- a/Apps/guacamole/docker-compose.yml
+++ b/Apps/guacamole/docker-compose.yml
@@ -104,7 +104,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/guacamole.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/guacamole.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/healthchecks/docker-compose.yml
+++ b/Apps/healthchecks/docker-compose.yml
@@ -151,7 +151,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/healthchecks.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/healthchecks.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/homarr/docker-compose.yml
+++ b/Apps/homarr/docker-compose.yml
@@ -71,7 +71,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/homarr.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/homarr.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/home-assistant/docker-compose.yml
+++ b/Apps/home-assistant/docker-compose.yml
@@ -62,7 +62,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/home-assistant.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/home-assistant.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/homebridge/docker-compose.yml
+++ b/Apps/homebridge/docker-compose.yml
@@ -54,7 +54,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/homebridge.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/homebridge.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/homer/docker-compose.yml
+++ b/Apps/homer/docker-compose.yml
@@ -65,7 +65,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/homer.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/homer.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ihatemoney/docker-compose.yml
+++ b/Apps/ihatemoney/docker-compose.yml
@@ -112,7 +112,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ihatemoney.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ihatemoney.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/immich-aio-alpine/docker-compose.yml
+++ b/Apps/immich-aio-alpine/docker-compose.yml
@@ -153,7 +153,7 @@ x-casaos:
     en_us: Immich All In One Alpine
   developer: "imagegenius" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/immich.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/immich.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -107,7 +107,7 @@ x-casaos:
     en_us: Immich without machine learning
   developer: "immich" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/immich.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/immich.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -169,7 +169,7 @@ x-casaos:
     en_us: Immich
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/immich.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/immich.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/invoice-ninja/docker-compose.yml
+++ b/Apps/invoice-ninja/docker-compose.yml
@@ -232,7 +232,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/invoiceninja.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/invoice-ninja.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/it-tools/docker-compose.yml
+++ b/Apps/it-tools/docker-compose.yml
@@ -47,7 +47,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/it-tools.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/it-tools.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/jellystat/docker-compose.yml
+++ b/Apps/jellystat/docker-compose.yml
@@ -97,7 +97,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/jellystat.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellystat.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/jlesage-firefox/docker-compose.yml
+++ b/Apps/jlesage-firefox/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         - container: /config
           description:
             en_us: "Container Path: /config"
-            
+
 # Global CasaOS specific configuration
 x-casaos:
   architectures: # Supported CPU architectures for the application
@@ -41,7 +41,7 @@ x-casaos:
     en_us: This project implements a Docker container for Firefox. # Short description or tagline in English
   developer: "jlesage" # Developer's name or identifier (currently empty)
   author: BigBearTechWorld # Author of this Docker Compose configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/firefox.png # Icon URL for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/firefox.png # Icon URL for the application
   thumbnail: "" # Thumbnail image URL
   title:
     en_us: Jlesage Firefox # Title in English

--- a/Apps/joplin/docker-compose.yml
+++ b/Apps/joplin/docker-compose.yml
@@ -126,7 +126,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/joplin.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/joplin.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/kavita/docker-compose.yml
+++ b/Apps/kavita/docker-compose.yml
@@ -67,7 +67,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/kavita.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/kavita.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/kiwix-serve/docker-compose.yml
+++ b/Apps/kiwix-serve/docker-compose.yml
@@ -59,7 +59,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/kiwix.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/kiwix.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/komf/docker-compose.yml
+++ b/Apps/komf/docker-compose.yml
@@ -100,7 +100,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/komf.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/komga.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/komga/docker-compose.yml
+++ b/Apps/komga/docker-compose.yml
@@ -67,7 +67,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/komga.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/komga.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/kopia/docker-compose.yml
+++ b/Apps/kopia/docker-compose.yml
@@ -89,7 +89,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/kopia.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/kopia.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/lancache/docker-compose.yml
+++ b/Apps/lancache/docker-compose.yml
@@ -114,7 +114,7 @@ x-casaos:
     en_us: LAN Party game caching made easy
   developer: "lancachenet" # Developer name
   author: BigBearTechWorld # Configuration author
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/lancache.png # Application icon
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/lancache.png # Application icon
   thumbnail: "" # Thumbnail image (empty)
   title:
     en_us: LAN Cache # Application title

--- a/Apps/linkstack/docker-compose.yml
+++ b/Apps/linkstack/docker-compose.yml
@@ -77,7 +77,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application (replace with actual LinkStack icon URL if available)
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/linkstack.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/linkstack.png
   # Thumbnail image (currently empty, replace if available)
   thumbnail: ""
   title:

--- a/Apps/linkwarden/docker-compose.yml
+++ b/Apps/linkwarden/docker-compose.yml
@@ -109,7 +109,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/linkwarden.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/linkwarden.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/lobe-chat/docker-compose.yml
+++ b/Apps/lobe-chat/docker-compose.yml
@@ -67,7 +67,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/lobe-chat.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/lobe-chat.png
   # Thumbnail image (currently empty)
   thumbnail: "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-casaos@main/Apps/lobe-chat/thumbnail.png"
   screenshot_link:
@@ -84,4 +84,3 @@ x-casaos:
     before_install:
       en_us: |
         Read this before installing: https://community.bigbeartechworld.com/t/added-lobe-chat-to-bigbearcasaos/2453?u=dragonfire1119
-    

--- a/Apps/mealie/docker-compose.yml
+++ b/Apps/mealie/docker-compose.yml
@@ -56,7 +56,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/mealie.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/mealie.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/minio/docker-compose.yml
+++ b/Apps/minio/docker-compose.yml
@@ -46,7 +46,7 @@ x-casaos:
     en_us: An open-source S3 alternative # Short description or tagline in English
   developer: "minio" # Developer's name or identifier
   author: BigBearCommunity # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons@master/png/minio.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/minio.png # Icon for the application
   thumbnail: "" # Thumbnail image (currently empty)
   title:
     en_us: Minio # Title in English

--- a/Apps/monica/docker-compose.yml
+++ b/Apps/monica/docker-compose.yml
@@ -107,7 +107,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/monica.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/monica.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/mumble-server/docker-compose.yml
+++ b/Apps/mumble-server/docker-compose.yml
@@ -41,7 +41,7 @@ x-casaos:
   # Author's name
   author: BigBearTechWorld
   # Icon URL
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/mumble.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/mumble.png
   # Thumbnail (empty in this case)
   thumbnail: ""
   # Title in English

--- a/Apps/n8n/docker-compose.yml
+++ b/Apps/n8n/docker-compose.yml
@@ -95,7 +95,7 @@ x-casaos:
     en_us: Workflow automation tool # Short description or tagline in English
   developer: "n8n" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/n8n.png # Icon URL
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/n8n.png # Icon URL
   thumbnail: "" # Thumbnail image URL (empty if not available)
   title:
     en_us: n8n # Title in English

--- a/Apps/neko-firefox/docker-compose.yml
+++ b/Apps/neko-firefox/docker-compose.yml
@@ -88,7 +88,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/neko.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/neko.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/netalertx/docker-compose.yml
+++ b/Apps/netalertx/docker-compose.yml
@@ -70,7 +70,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pi-alert.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/pi-alert.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/nextcloud-ls/docker-compose.yml
+++ b/Apps/nextcloud-ls/docker-compose.yml
@@ -68,7 +68,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextcloud.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png
   # Thumbnail image (currently empty)
   thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg
   screenshot_link:

--- a/Apps/nextcloud-with-smbclient/docker-compose.yml
+++ b/Apps/nextcloud-with-smbclient/docker-compose.yml
@@ -196,7 +196,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextcloud.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png
   # Thumbnail image (currently empty)
   thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg
   screenshot_link:

--- a/Apps/nextcloud/docker-compose.yml
+++ b/Apps/nextcloud/docker-compose.yml
@@ -195,7 +195,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextcloud.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png
   # Thumbnail image (currently empty)
   thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg
   screenshot_link:

--- a/Apps/nightscout/docker-compose.yml
+++ b/Apps/nightscout/docker-compose.yml
@@ -140,7 +140,7 @@ x-casaos:
   author: BigBearTechWorld
 
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nightscout.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/nightscout.png
 
   # Thumbnail image
   thumbnail: "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-casaos/Apps/nightscout/screenshot.png"

--- a/Apps/nocodb/docker-compose.yml
+++ b/Apps/nocodb/docker-compose.yml
@@ -90,7 +90,7 @@ x-casaos:
     en_us: 🔥 🔥 🔥 Open Source Airtable Alternative
   developer: "nocodb" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nocodb.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/nocodb.png # Icon for the application
   thumbnail: "https://user-images.githubusercontent.com/86527202/277104231-e2fad786-f211-4dcb-9bd3-aaece83a6783.gif" # Thumbnail image (currently empty)
   title:
     en_us: NocoDB # Title in English

--- a/Apps/node-red/docker-compose.yml
+++ b/Apps/node-red/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   author: BigBearTechWorld
 
   # Icon for the service
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/node-red.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/node-red.png
 
   # Thumbnail for the service (if applicable)
   thumbnail: ""

--- a/Apps/npmplus/docker-compose.yml
+++ b/Apps/npmplus/docker-compose.yml
@@ -57,7 +57,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/npmplus.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/nginx-proxy-manager.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ntfysh/docker-compose.yml
+++ b/Apps/ntfysh/docker-compose.yml
@@ -77,7 +77,7 @@ x-casaos:
   author: BigBearTechWorld
 
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ntfy.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ntfy.png
 
   # Thumbnail or screenshot URL for the application
   thumbnail: https://ntfy.sh/_next/static/media/screenshot-web-3.de6f19af.png

--- a/Apps/obsidian-livesync/docker-compose.yml
+++ b/Apps/obsidian-livesync/docker-compose.yml
@@ -63,7 +63,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/obsidian.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/obsidian.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/obsidian/docker-compose.yml
+++ b/Apps/obsidian/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/obsidian.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/obsidian.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/octoprint/docker-compose.yml
+++ b/Apps/octoprint/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/octoprint.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/octoprint.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ollama-amd/docker-compose.yml
+++ b/Apps/ollama-amd/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ollama.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ollama-cpu/docker-compose.yml
+++ b/Apps/ollama-cpu/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ollama.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/ollama-nvidia/docker-compose.yml
+++ b/Apps/ollama-nvidia/docker-compose.yml
@@ -69,7 +69,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/ollama.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ollama.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/onedev/docker-compose.yml
+++ b/Apps/onedev/docker-compose.yml
@@ -119,7 +119,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/onedev.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/onedev.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/onlyoffice/docker-compose.yml
+++ b/Apps/onlyoffice/docker-compose.yml
@@ -52,7 +52,7 @@ x-casaos:
     en_us: OnlyOffice # Short description or tagline in English
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/onlyoffice.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/onlyoffice.png # Icon for the application
   thumbnail: "" # Thumbnail image (currently empty)
   title:
     en_us: OnlyOffice # Title in English

--- a/Apps/open-webui/docker-compose.yml
+++ b/Apps/open-webui/docker-compose.yml
@@ -60,7 +60,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/open-webui.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/open-webui.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/owncloud/docker-compose.yml
+++ b/Apps/owncloud/docker-compose.yml
@@ -205,7 +205,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/owncloud.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/owncloud.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/paperless-ngx/docker-compose.yml
+++ b/Apps/paperless-ngx/docker-compose.yml
@@ -211,7 +211,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/paperless.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/paperless-ngx.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/photoprism/docker-compose.yml
+++ b/Apps/photoprism/docker-compose.yml
@@ -212,7 +212,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/photoprism.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/photoprism.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/phpmyadmin/docker-compose.yml
+++ b/Apps/phpmyadmin/docker-compose.yml
@@ -69,7 +69,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/phpmyadmin.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/phpmyadmin.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/pihole-unbound/docker-compose.yml
+++ b/Apps/pihole-unbound/docker-compose.yml
@@ -91,7 +91,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pi-hole-unbound.png
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/pi-hole-unbound.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/pihole-updatelists/docker-compose.yml
+++ b/Apps/pihole-updatelists/docker-compose.yml
@@ -116,7 +116,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pi-hole.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/pi-hole.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/pihole/docker-compose.yml
+++ b/Apps/pihole/docker-compose.yml
@@ -91,7 +91,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pi-hole.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/pi-hole.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/pingvin-share/docker-compose.yml
+++ b/Apps/pingvin-share/docker-compose.yml
@@ -47,7 +47,7 @@ x-casaos:
     en_us: Pingvin Share
   developer: "stonith404"
   author: BigBearTechWorld
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pingvin.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/pingvin-share.png
   thumbnail: "https://user-images.githubusercontent.com/58886915/225038319-b2ef742c-3a74-4eb6-9689-4207a36842a4.png"
   title:
     en_us: Pingvin Share

--- a/Apps/piwigo/docker-compose.yml
+++ b/Apps/piwigo/docker-compose.yml
@@ -102,7 +102,7 @@ x-casaos:
     en_us: Piwigo # Short description or tagline in English
   developer: "piwigo" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/piwigo.png # Icon for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/piwigo.png # Icon for the application
   thumbnail: "" # Thumbnail image (currently empty)
   title:
     en_us: Piwigo # Title in English

--- a/Apps/planka/docker-compose.yml
+++ b/Apps/planka/docker-compose.yml
@@ -146,7 +146,7 @@ x-casaos:
     en_us: Free open source kanban board for workgroups.
   developer: "plankanban"
   author: BigBearTechWorld
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/planka.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/planka.png
   thumbnail: ""
   title:
     en_us: Planka

--- a/Apps/plex/docker-compose.yml
+++ b/Apps/plex/docker-compose.yml
@@ -64,7 +64,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/plex.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/plex.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/pterodactyl-panel/docker-compose.yml
+++ b/Apps/pterodactyl-panel/docker-compose.yml
@@ -168,7 +168,7 @@ x-casaos:
     en_us: Pterodactyl Panel
   developer: "pterodactyl" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pterodactyl.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/pterodactyl.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/pterodactyl-wings/docker-compose.yml
+++ b/Apps/pterodactyl-wings/docker-compose.yml
@@ -115,7 +115,7 @@ x-casaos:
     en_us: Pterodactyl Wings
   developer: "pterodactyl" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pterodactyl.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/pterodactyl.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/rallly/docker-compose.yml
+++ b/Apps/rallly/docker-compose.yml
@@ -127,7 +127,7 @@ x-casaos:
     en_us: Rallly # Short tagline or slogan
   developer: "lukevella" # Developer or maintainer of the application
   author: BigBearTechWorld # The author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/rallly.png # Icon URL
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/rallly.png # Icon URL
   thumbnail: "" # Thumbnail image URL (currently empty)
   title:
     en_us: Rallly # Title of the application in English

--- a/Apps/romm/docker-compose.yml
+++ b/Apps/romm/docker-compose.yml
@@ -173,7 +173,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/romm.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/romm.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/scrutiny/docker-compose.yml
+++ b/Apps/scrutiny/docker-compose.yml
@@ -111,7 +111,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/scrutiny.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/scrutiny.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/scrypted/docker-compose.yml
+++ b/Apps/scrypted/docker-compose.yml
@@ -96,7 +96,7 @@ x-casaos:
     en_us: Scrypted
   developer: "koush" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/scrypted.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/scrypted.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   # Title of the application in English

--- a/Apps/seafile/docker-compose.yml
+++ b/Apps/seafile/docker-compose.yml
@@ -117,7 +117,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/seafile.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/seafile.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/semaphore/docker-compose.yml
+++ b/Apps/semaphore/docker-compose.yml
@@ -105,7 +105,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/semaphore.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/semaphore-ui.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/sftpgo/docker-compose.yml
+++ b/Apps/sftpgo/docker-compose.yml
@@ -79,7 +79,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/sftpgo.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/sftpgo.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/syncthing/docker-compose.yml
+++ b/Apps/syncthing/docker-compose.yml
@@ -69,7 +69,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/syncthing.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/syncthing.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/tailscale/docker-compose.yml
+++ b/Apps/tailscale/docker-compose.yml
@@ -102,7 +102,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/tailscale.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/tailscale.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/tp-link-omada-controller/docker-compose.yml
+++ b/Apps/tp-link-omada-controller/docker-compose.yml
@@ -151,7 +151,7 @@ x-casaos:
   author: BigBearTechWorld
 
   # Icons and thumbnails for CasaOS dashboard.
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/omada.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/omada.png
   thumbnail: ""
 
   # Title for the CasaOS dashboard.

--- a/Apps/traccar/docker-compose.yml
+++ b/Apps/traccar/docker-compose.yml
@@ -56,7 +56,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/traccar.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/traccar.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/trilium/docker-compose.yml
+++ b/Apps/trilium/docker-compose.yml
@@ -60,7 +60,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/trilium.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/trilium.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/umami/docker-compose.yml
+++ b/Apps/umami/docker-compose.yml
@@ -88,7 +88,7 @@ x-casaos:
   author: BigBearTechWorld
 
   # URL pointing to the icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/umami.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/umami.png
 
   # URL pointing to a thumbnail image representing the application
   thumbnail: ""

--- a/Apps/umbrel-os/docker-compose.yml
+++ b/Apps/umbrel-os/docker-compose.yml
@@ -62,7 +62,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/umbrel.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/umbrelos.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/unifi-network-application-mongo-4/docker-compose.yml
+++ b/Apps/unifi-network-application-mongo-4/docker-compose.yml
@@ -162,7 +162,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/unifi.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ubiquiti-unifi.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/unifi-network-application/docker-compose.yml
+++ b/Apps/unifi-network-application/docker-compose.yml
@@ -162,7 +162,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/unifi.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/ubiquiti-unifi.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/upsnap/docker-compose.yml
+++ b/Apps/upsnap/docker-compose.yml
@@ -60,7 +60,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/upsnap.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/upsnap.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/uptime-kuma/docker-compose.yml
+++ b/Apps/uptime-kuma/docker-compose.yml
@@ -50,7 +50,7 @@ x-casaos:
   # Author of this configuration file for tracking and support
   author: BigBearTechWorld
   # Icon URL for the application, used for visual identification in UIs
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/uptime-kuma.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/uptime-kuma.png
   # Placeholder for thumbnail image (can be updated later)
   thumbnail: ""
   # Application title in English, used for display purposes

--- a/Apps/vikunja/docker-compose.yml
+++ b/Apps/vikunja/docker-compose.yml
@@ -122,7 +122,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/vikunja.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/vikunja.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/wallos/docker-compose.yml
+++ b/Apps/wallos/docker-compose.yml
@@ -70,7 +70,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/wallos.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/wallos.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/watchyourlan/docker-compose.yml
+++ b/Apps/watchyourlan/docker-compose.yml
@@ -43,7 +43,6 @@ services:
           description:
             en_us: "Container Path: /data/WatchYourLAN"
 
-
 # CasaOS specific configuration
 x-casaos:
   # Supported CPU architectures for the application
@@ -63,7 +62,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/watchyourlan.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/watchyourlan.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:

--- a/Apps/whats-up-docker/docker-compose.yml
+++ b/Apps/whats-up-docker/docker-compose.yml
@@ -43,7 +43,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/whats-up-docker.png
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/whats-up-docker.png
   # Thumbnail image URL for the application (currently empty)
   thumbnail: ""
   # Title for the application

--- a/Apps/wordpress/docker-compose.yml
+++ b/Apps/wordpress/docker-compose.yml
@@ -103,7 +103,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon URL for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/wordpress.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/wordpress.png
   # Thumbnail image URL for the application (currently empty)
   thumbnail: ""
   # Title for the application

--- a/Apps/zigbee2mqtt/docker-compose.yml
+++ b/Apps/zigbee2mqtt/docker-compose.yml
@@ -67,7 +67,7 @@ x-casaos:
   # Author of this configuration
   author: BigBearTechWorld
   # Icon for the application
-  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/zigbee2mqtt.png
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/zigbee2mqtt.png
   # Thumbnail image (currently empty)
   thumbnail: ""
   title:


### PR DESCRIPTION
- Updates icon URLs for various applications in the CasaOS app store to use the selfhst/icons repository instead of the walkxcode/dashboard-icons repository
- Ensures application icons are consistently sourced from a reliable and maintained icon set
- Updates icons for applications including Home Assistant, Nextcloud, Unifi Network Application, Authentik, Firefox, Upsnap, OwnCloud, Komga, Ollama CPU, IT Tools, Joplin, TP-Link Omada Controller, and Ollama AMD