### PR TITLE
🔖 docs(README): update app store URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you have a feature request please post in the [BigBearCommunity](https://comm
 ## App Store URL
 
 ```text
-https://icewhale.bigbeartechworld.com/big-bear-casaos.zip
+https://github.com/bigbeartechworld/big-bear-casaos/archive/refs/heads/master.zip
 ```
 
 ## App Store Suggestions


### PR DESCRIPTION
- Updated the app store URL in the README to point to the GitHub repository's master branch zip file instead of the old URL
- This change is necessary to provide users with the latest version of the application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the App Store download link in the README to point to the latest version hosted on GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->