### PR TITLE
🔖 docs(README): update app store URL

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -55,7 +55,7 @@ If you have a feature request please post in the [BigBearCommunity](https://comm
 ## App Store URL
 
 ```text
-https://icewhale.bigbeartechworld.com/big-bear-casaos.zip
+https://github.com/bigbeartechworld/big-bear-casaos/archive/refs/heads/master.zip
 ```
 
 ## App Store Suggestions


### PR DESCRIPTION
- Updated the app store URL in the README.md file to point to the GitHub repository's master branch zip file instead of the icewhale.bigbeartechworld.com URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "App Store URL" in the README to reference the latest GitHub archive link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->