### PR TITLE
feat: add goaway DNS sinkhole app

### DIFF
--- a/Apps/goaway/config.json
+++ b/Apps/goaway/config.json
@@ -1,0 +1,8 @@
+{
+  "id": "goaway",
+  "version": "0.60.8",
+  "image": "pommee/goaway",
+  "youtube": "",
+  "docs_link": "https://community.bigbeartechworld.com/t/added-goaway-to-bigbearcasaos/4085",
+  "big_bear_cosmos_youtube": ""
+}

--- a/Apps/goaway/docker-compose.yml
+++ b/Apps/goaway/docker-compose.yml
@@ -1,0 +1,83 @@
+# Configuration for goaway setup
+
+# Application Name
+name: big-bear-goaway
+
+# Services used in the application
+services:
+  # The `big-bear-goaway` service for the goaway application
+  big-bear-goaway:
+    # Name of the container
+    container_name: big-bear-goaway
+    # Docker image to be used
+    image: pommee/goaway:0.60.8
+    # Restart policy for the service
+    restart: unless-stopped
+    # Port mappings for the service
+    ports:
+      - "53:53/udp" # DNS port UDP
+      - "53:53/tcp" # DNS port TCP
+      - "8080:8080" # Web dashboard port
+    # Network mode for the service
+    network_mode: bridge
+    # Volumes for the service HOST -> CONTAINER
+    volumes:
+      - /DATA/AppData/$AppID/config:/app/config
+    # Capabilities required for DNS services
+    cap_add:
+      - NET_BIND_SERVICE
+      - NET_RAW
+    # CasaOS specific configuration for the app service
+    x-casaos:
+      volumes:
+        - container: /app/config
+          description:
+            en_us: "Container Path: /app/config"
+      ports:
+        - container: "53"
+          description:
+            en_us: "Container Port: 53 (DNS)"
+          protocol: udp
+        - container: "53"
+          description:
+            en_us: "Container Port: 53 (DNS)"
+          protocol: tcp
+        - container: "8080"
+          description:
+            en_us: "Container Port: 8080 (Web Dashboard)"
+
+# CasaOS global application configuration
+x-casaos:
+  # Supported CPU architectures for this application
+  architectures:
+    - amd64
+    - arm64
+  # Main service for this application
+  main: big-bear-goaway
+  # Detailed description for the application
+  description:
+    en_us: GoAway is a lightweight DNS sinkhole that blocks ads, trackers, and malicious domains at the network level. It provides a web-based admin dashboard for management and supports customizable blocking rules with real-time statistics tracking.
+  # Brief tagline for the application
+  tagline:
+    en_us: Lightweight DNS sinkhole for blocking ads and trackers
+  # Developer's information
+  developer: "pommee"
+  # Author of this particular configuration
+  author: BigBearTechWorld
+  # Icon URL for the application
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/goaway.png
+  # Thumbnail image for the application (if any)
+  thumbnail: ""
+  # Title for the application
+  title:
+    en_us: GoAway
+  # Category under which the application falls
+  category: BigBearCasaOS
+  # Default port mapping for the application
+  port_map: "8080"
+  # This is shown before installing
+  tips:
+    before_install:
+      en_us: |
+        Visit the community post for setup instructions and community support:
+        https://community.bigbeartechworld.com/t/added-goaway-to-bigbearcasaos/4085


### PR DESCRIPTION
## Summary

- Add GoAway v0.60.8 lightweight DNS sinkhole for network-level ad blocking
- Configure proper x-casaos metadata with dual DNS ports (53 UDP/TCP) and web UI (8080)
- Include required capabilities (NET_BIND_SERVICE, NET_RAW) for DNS functionality
- Include before_install tips with community link for support
- Support amd64 and arm64 architectures

## About GoAway

GoAway is a lightweight DNS sinkhole that blocks ads, trackers, and malicious domains at the network level. Unlike browser-based ad blockers that only protect individual browsers, GoAway works at the DNS level to protect entire networks.

## Key Features

- Network-wide protection for all devices
- Lightweight and fast (< 50MB RAM usage)
- Web-based admin dashboard on port 8080
- Customizable blocking rules
- Real-time statistics tracking

## Configuration

- **DNS Ports**: 53 (UDP/TCP)
- **Web Dashboard**: 8080
- **Required Capabilities**: NET_BIND_SERVICE, NET_RAW
- **Architectures**: amd64, arm64

## Community Support

Users can find setup instructions and support at:
https://community.bigbeartechworld.com/t/added-goaway-to-bigbearcasaos/4085

## Test plan

- [x] Docker compose configuration validates successfully
- [x] All required x-casaos metadata included
- [x] Tests pass with new app configuration
- [x] Before install tips include community support link