### PR TITLE
Fix Stalwart Mail

### DIFF
--- a/Apps/stalwart-mail/config.json
+++ b/Apps/stalwart-mail/config.json
@@ -1,5 +1,5 @@
 {
-  "id": "stalwart",
+  "id": "stalwart-mail",
   "version": "0.13.2",
   "image": "stalwartlabs/stalwart",
   "youtube": "",

--- a/Apps/stalwart-mail/config.json
+++ b/Apps/stalwart-mail/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "stalwart-mail",
-  "version": "0.11.8",
-  "image": "stalwartlabs/mail-server",
+  "id": "stalwart",
+  "version": "0.13.2",
+  "image": "stalwartlabs/stalwart",
   "youtube": "",
   "docs_link": "",
   "big_bear_cosmos_youtube": ""

--- a/Apps/stalwart-mail/docker-compose.yml
+++ b/Apps/stalwart-mail/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     container_name: big-bear-stalwart-mail
 
     # Image to be used for the container specifies the stalwartlabs/mail-server version and source
-    image: stalwartlabs/stalwart:latest
+    image: stalwartlabs/stalwart:v0.13.2
 
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped

--- a/Apps/stalwart-mail/docker-compose.yml
+++ b/Apps/stalwart-mail/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     container_name: big-bear-stalwart-mail
 
     # Image to be used for the container specifies the stalwartlabs/mail-server version and source
-    image: stalwartlabs/mail-server:v0.11.8
+    image: stalwartlabs/stalwart:latest
 
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped


### PR DESCRIPTION
- Changed to latest
- Changed to new image - stalwart, not mail-server, as said in installation guide on stalwart:
```
$ docker pull stalwartlabs/stalwart:lates
```
[Source](https://stalw.art/docs/install/platform/docker)

The [stalwartlabs/mail-server](https://hub.docker.com/r/stalwartlabs/mail-server) is archived.