### PR TITLE
fix: update upsnap version to 5.1.9 in config.json

### DIFF
--- a/Apps/upsnap/config.json
+++ b/Apps/upsnap/config.json
@@ -1,6 +1,6 @@
 {
   "id": "upsnap",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "image": "ghcr.io/seriousm4x/upsnap",
   "youtube": "",
   "docs_link": "",


### PR DESCRIPTION
## Summary
• Fixed version mismatch between config.json (5.1.8) and docker-compose.yml (5.1.9)
• Updated config.json version to 5.1.9 to match docker-compose.yml

## Test plan
- [x] Run tests to verify version consistency check passes
- [x] Verify both files now have matching version 5.1.9