### PR TITLE
fix: update authentik postgres to 14-alpine for compatibility

### DIFF
--- a/Apps/authentik/docker-compose.yml
+++ b/Apps/authentik/docker-compose.yml
@@ -98,7 +98,10 @@ services:
 
   big-bear-authentik-db:
     container_name: big-bear-authentik-db
-    image: postgres:12-alpine
+    # PostgreSQL 14+ required by Authentik (since version 2024.6)
+    # BREAKING CHANGE: Existing users with PostgreSQL 12 data need to migrate
+    # See: https://www.postgresql.org/docs/current/upgrading.html
+    image: postgres:14-alpine
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]


### PR DESCRIPTION
## Summary
- Updates PostgreSQL from 12-alpine to 14-alpine in Authentik configuration
- Fixes compatibility issue where Authentik requires PostgreSQL 14+ since version 2024.6
- Adds clear migration notes and warnings for existing users

## Details
The current PostgreSQL 12-alpine configuration is incompatible with recent Authentik versions (2024.6+), which require PostgreSQL 14 or later. This change:

- Uses PostgreSQL 14-alpine (minimum supported version)
- Includes comments explaining the breaking change
- References PostgreSQL upgrade documentation for existing users

## Breaking Change Notice
⚠️ **This is a breaking change for existing installations with PostgreSQL 12 data.** Users will need to migrate their database before upgrading. See the PostgreSQL upgrade documentation for migration steps.

## Test plan
- [ ] New Authentik installations should start successfully
- [ ] Existing users are warned about migration requirements
- [ ] PostgreSQL 14-alpine is compatible with current Authentik versions

Fixes #4991