### PR TITLE
✨ bump(immich): upgrade Immich images to v2.0.0

### DIFF
--- a/Apps/immich-aio-alpine/config.json
+++ b/Apps/immich-aio-alpine/config.json
@@ -1,6 +1,6 @@
 {
   "id": "immich-aio-alpine",
-  "version": "1.131.3-alpine",
+  "version": "2.0.0-alpine",
   "image": "ghcr.io/imagegenius/immich",
   "youtube": "",
   "docs_link": "",

--- a/Apps/immich-aio-alpine/docker-compose.yml
+++ b/Apps/immich-aio-alpine/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # Main Immich Server service configuration
   big-bear-immich-aio-alpine:
     container_name: big-bear-immich-aio-alpine # Name of the running container
-    image: ghcr.io/imagegenius/immich:1.131.3-alpine # Image to be used
+    image: ghcr.io/imagegenius/immich:2.0.0-alpine # Image to be used
     ports: # Mapping ports from the host OS to the container
       - 2283:8080
     volumes: # Mounting directories for persistent data storage

--- a/Apps/immich-without-machine-learning/config.json
+++ b/Apps/immich-without-machine-learning/config.json
@@ -1,6 +1,6 @@
 {
   "id": "immich-without-machine-learning",
-  "version": "1.143.1",
+  "version": "2.0.0",
   "image": "ghcr.io/immich-app/immich-server",
   "youtube": "https://youtu.be/ZIx2jDHYjjE",
   "docs_link": "",

--- a/Apps/immich-without-machine-learning/docker-compose.yml
+++ b/Apps/immich-without-machine-learning/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # Main Immich Server service configuration
   immich-server:
     container_name: immich-server # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v1.143.1 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v2.0.0 # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding

--- a/Apps/immich/config.json
+++ b/Apps/immich/config.json
@@ -1,6 +1,6 @@
 {
   "id": "immich",
-  "version": "1.143.1",
+  "version": "2.0.0",
   "image": "ghcr.io/immich-app/immich-server",
   "youtube": "https://youtu.be/ZIx2jDHYjjE",
   "docs_link": "",

--- a/Apps/immich/docker-compose.yml
+++ b/Apps/immich/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # Main Immich Server service configuration
   immich-server:
     container_name: immich-server # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v1.143.1 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v2.0.0 # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
@@ -66,7 +66,7 @@ services:
   # Configuration for Immich Machine Learning service
   immich-machine-learning:
     container_name: immich-machine-learning # Name of the running container
-    image: ghcr.io/immich-app/immich-machine-learning:v1.143.1 # Image to be used
+    image: ghcr.io/immich-app/immich-machine-learning:v2.0.0 # Image to be used
     volumes: # Mounting directories for persistent data storage
       - /DATA/AppData/$AppID/model-cache:/cache
     environment: # Setting environment variables
@@ -153,19 +153,23 @@ services:
           description:
             en_us: "Container Path: /var/lib/postgresql/data"
 
-networks: # Defines network configurations for the services
+networks:
+  # Defines network configurations for the services
   big_bear_immich_network:
     driver: bridge # Uses bridge network driver
 
 # CasaOS specific configuration
 x-casaos:
-  architectures: # Supported CPU architectures
+  architectures:
+    # Supported CPU architectures
     - amd64
     - arm64
   main: immich-server # Main service of the application
-  description: # Description in different languages
+  description:
+    # Description in different languages
     en_us: Self-hosted photo and video storage.
-  tagline: # Short description or tagline in different languages
+  tagline:
+    # Short description or tagline in different languages
     en_us: Immich
   developer: "" # Developer's name or identifier
   author: BigBearTechWorld # Author of this configuration


### PR DESCRIPTION
Update Docker Compose and app metadata to use Immich v2.0.0
images and corresponding alpine image tag. This changes the server
and machine-learning container images from v1.143.1 to v2.0.0, and
updates the imagegenius immich alpine build from 1.131.3-alpine to
2.0.0-alpine. Also update config.json version fields to reflect the
new image tags.

Reason: bring deployments up to the new major Immich release to pick
up features, fixes, and compatibility improvements. Ensure config
metadata matches the deployed image versions.

- Bump server container image from v1.143.1 to v2.0.0
- Bump machine-learning container image from v1.143.1 to v2.0.0
- Update imagegenius immich alpine build from 1.131.3-alpine to 2.0.0-alpine
- Update config.json version fields to reflect new image tags