### PR TITLE
🔧 fix(tugtainer): Remove SHA256 hash from version references

### DIFF
--- a/Apps/tugtainer/config.json
+++ b/Apps/tugtainer/config.json
@@ -1,6 +1,6 @@
 {
   "id": "tugtainer",
-  "version": "1.1.6@sha256:3bb2dc4e3b428719b015252253ae88fd4efdc224b93bfb089946c198bd779586",
+  "version": "v1.1.6",
   "image": "quenary/tugtainer",
   "youtube": "",
   "docs_link": "",

--- a/Apps/tugtainer/docker-compose.yml
+++ b/Apps/tugtainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-tugtainer
 
     # Image to be used for the container
-    image: quenary/tugtainer:v1.1.6@sha256:3bb2dc4e3b428719b015252253ae88fd4efdc224b93bfb089946c198bd779586
+    image: quenary/tugtainer:v1.1.6
 
     # Container restart policy
     restart: unless-stopped


### PR DESCRIPTION
• Removed hardcoded SHA256 hash from config and docker-compose files
• Improved version tracking and readability