### PR TITLE
📝 Update Wireguard Easy app title to indicate legacy status

### DIFF
--- a/Apps/wg-easy/docker-compose.yml
+++ b/Apps/wg-easy/docker-compose.yml
@@ -82,7 +82,7 @@ x-casaos:
   thumbnail: ""
   title:
     # Title in English
-    en_us: Wireguard Easy
+    en_us: Wireguard Easy 14 (Legacy)
   # Application category
   category: BigBearCasaOS
   # Port mapping information


### PR DESCRIPTION
• Updated application title to indicate legacy status
• Improved user understanding of the application's current state
• Clarified potential future changes for Wireguard Easy