### PR TITLE
🔧 fix(docker-compose): Escape quotes in description and tagline

### DIFF
--- a/Apps/beaverhabits/docker-compose.yml
+++ b/Apps/beaverhabits/docker-compose.yml
@@ -71,9 +71,9 @@ x-casaos:
     - arm64
   main: big-bear-beaverhabits
   description:
-    en_us: A self-hosted habit tracking app without \"Goals\"
+    en_us: 'A self-hosted habit tracking app without "Goals"'
   tagline:
-    en_us: A self-hosted habit tracking app without \"Goals\"
+    en_us: 'A self-hosted habit tracking app without "Goals"'
   developer: "daya0576"
   author: BigBearTechWorld
   icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/png/beaver-habit-tracker.png"

--- a/Apps/chatpad/docker-compose.yml
+++ b/Apps/chatpad/docker-compose.yml
@@ -38,7 +38,7 @@ x-casaos:
   main: big-bear-chatpad
   description:
     # Description in English
-    en_us: Recently, there has been a surge of UIs for ChatGPT, making it the new \"to-do app\" that everyone wants to try their hand at. Chatpad sets itself apart with a broader vision - to become the ultimate interface for ChatGPT users.
+    en_us: 'Recently, there has been a surge of UIs for ChatGPT, making it the new "to-do app" that everyone wants to try their hand at. Chatpad sets itself apart with a broader vision - to become the ultimate interface for ChatGPT users.'
   tagline:
     # Short description or tagline in English
     en_us: Not just another ChatGPT user-interface!

--- a/Apps/cyberchef/docker-compose.yml
+++ b/Apps/cyberchef/docker-compose.yml
@@ -38,7 +38,7 @@ x-casaos:
   main: big-bear-cyberchef
   description:
     # Description in English
-    en_us: CyberChef is a simple, intuitive web app for carrying out all manner of \"cyber\" operations within a web browser. These operations include simple encoding like XOR and Base64, more complex encryption like AES, DES and Blowfish, creating binary and hexdumps, compression and decompression of data, calculating hashes and checksums, IPv6 and X.509 parsing, changing character encodings, and much more.
+    en_us: 'CyberChef is a simple, intuitive web app for carrying out all manner of "cyber" operations within a web browser. These operations include simple encoding like XOR and Base64, more complex encryption like AES, DES and Blowfish, creating binary and hexdumps, compression and decompression of data, calculating hashes and checksums, IPv6 and X.509 parsing, changing character encodings, and much more.'
   tagline:
     # Short description or tagline in English
     en_us: The Cyber Swiss Army Knife


### PR DESCRIPTION
## Overview

- Escaped quotes in docker-compose files for multiple applications
- Fixed potential YAML parsing issues for:
  - BeaverHabits
  - CyberChef
  - Chatpad

## Impact
Ensures correct configuration parsing and prevents potential deployment problems.