### PR TITLE
feat: adding the mqtt-antena app

### DIFF
--- a/Apps/MQTT-Antena/config.json
+++ b/Apps/MQTT-Antena/config.json
@@ -1,0 +1,7 @@
+{
+  "id": "mqtt-antena",
+  "version": "1.5.8",
+  "image": "fbossolan/mqtt-antena",
+  "youtube": "",
+  "docs_link": "https://fbossolan.github.io/mqtt-antena/"
+}

--- a/Apps/MQTT-Antena/docker-compose.yml
+++ b/Apps/MQTT-Antena/docker-compose.yml
@@ -1,0 +1,30 @@
+
+name: big-bear-mqtt-antena
+services:
+  mqtt-antena:
+    image: fbossolan/mqtt-antena:1.5.8
+    container_name: mqtt-antena
+    ports:
+      - "8585:8585"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - SECRET_KEY=your_secret_key_here
+    restart: unless-stopped
+x-casaos:
+  architectures:
+    - amd64
+    - arm64
+  main: mqtt-antena
+  author: fbossolan
+  category: IOT
+  description:
+    en_US: MQTT-Antena is a tool to manage MQTT messages.
+  developer: fbossolan
+  icon: https://github.com/fbossolan/mqtt-antena/blob/main/src/static/img/logo.png?raw=true 
+  tagline:
+    en_US: A simple way to manage MQTT.
+  title:
+    en_US: MQTT Antena
+  port_map: "8585"
+

--- a/Apps/MQTT-Antena/docker-compose.yml
+++ b/Apps/MQTT-Antena/docker-compose.yml
@@ -1,4 +1,3 @@
-
 name: big-bear-mqtt-antena
 services:
   mqtt-antena:
@@ -19,7 +18,7 @@ x-casaos:
   description:
     en_US: MQTT-Antena is a tool to manage MQTT messages.
   developer: fbossolan
-  icon: https://github.com/fbossolan/mqtt-antena/blob/main/src/static/img/logo.png?raw=true 
+  icon: https://github.com/fbossolan/mqtt-antena/blob/main/src/static/img/logo.png?raw=true
   tagline:
     en_US: A simple way to manage MQTT.
   title:

--- a/Apps/MQTT-Antena/docker-compose.yml
+++ b/Apps/MQTT-Antena/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - "8585:8585"
     volumes:
       - ./data:/app/data
-    environment:
-      - SECRET_KEY=your_secret_key_here
     restart: unless-stopped
 x-casaos:
   architectures:


### PR DESCRIPTION
This repo adds the files for the MQTT Antena application. The main documentation of the project can be found [here](https://fbossolan.github.io/mqtt-antena/).

## Tests:
The app was successfully built as a container using this configuration in a test CasaOS installation:


**Installed app:**
<img width="989" height="509" alt="test-installation-2" src="https://github.com/user-attachments/assets/c3eff436-5ac0-4962-a599-4d9135f818f9" />
<br>
**Inside the app:**
<img width="1082" height="735" alt="test-installation1" src="https://github.com/user-attachments/assets/88f14d79-9f2f-4457-bf23-2ecebd1fb187" />