### PR TITLE
Rename store metadata CasaOS → ZimaOS

### DIFF
--- a/store-config.json
+++ b/store-config.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
-  "store_id": "com.bigbeartechworld.casaos",
-  "name": { "en_US": "Big Bear CasaOS App Store" },
-  "description": { "en_US": "Community-maintained apps for CasaOS and ZimaOS by BigBearTechWorld." },
+  "store_id": "com.bigbeartechworld.zimaos",
+  "name": { "en_US": "Big Bear ZimaOS App Store" },
+  "description": { "en_US": "Community-maintained apps for ZimaOS by BigBearTechWorld." },
   "maintainer": "BigBearTechWorld",
   "url": "https://github.com/bigbeartechworld/big-bear-casaos"
 }


### PR DESCRIPTION
Renames store name, description, and store_id from CasaOS to ZimaOS since the upgrade targets ZimaOS.

Closes #6327